### PR TITLE
Adding a null check.

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicCharacterAvatar.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicCharacterAvatar.cs
@@ -1187,6 +1187,9 @@ namespace UMACharacterSystem
 		//NOTE needs to be public for the editor
 		public void UpdateColors(bool triggerDirty = false)
 		{
+		    if (umaData.umaRecipe.sharedColors == null)
+		        return;
+
 			foreach (UMA.OverlayColorData ucd in umaData.umaRecipe.sharedColors)
 			{
 				if (ucd.HasName())


### PR DESCRIPTION
When changing races I encounter a null ref exception for sharedColors.  Adding this null check negates this error and allows one to continue building their DCA.