### PR TITLE
Fixed bug in Shared Overlays. Added manual save to recipe editor

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicCharacterAvatar.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicCharacterAvatar.cs
@@ -2659,7 +2659,7 @@ namespace UMA.CharacterSystem
 							SortedOverlays.Add(od);
 						}
 					}
-					sd.SetOverlayList(SortedOverlays);
+					sd.UpdateOverlayList(SortedOverlays);
 				}
 			} 
 

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/RecipeEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/RecipeEditor.cs
@@ -72,6 +72,8 @@ namespace UMA.Editors
 
         public void OnEnable()
         {
+            base.OnEnable();
+
             if (!NeedsReenable())
                 return;
 

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/CharacterBaseEditor.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/CharacterBaseEditor.cs
@@ -661,9 +661,6 @@ namespace UMA.Editors
                     List<OverlayData> CurrentOverlays = sortedSlots[i].GetOverlays();
                     List<OverlayData> PreviousOverlays = sortedSlots[i-1].GetOverlays();
 
-                    int CurrentHash = CurrentOverlays.GetHashCode();
-                    int PreviousHash = PreviousOverlays.GetHashCode();
-
                     if (CurrentOverlays == PreviousOverlays)
                     {
                         sortedSlots[i].sharedOverlays = true;

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/CharacterBaseEditor.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/CharacterBaseEditor.cs
@@ -1713,6 +1713,24 @@ namespace UMA.Editors
 			return true;
 		}
 
+        public virtual void OnEnable()
+        {
+            _needsUpdate = false;
+            _forceUpdate = false;
+        }
+
+        public virtual void OnDisable()
+        {
+            if (_needsUpdate)
+            {
+                if (EditorUtility.DisplayDialog("Unsaved Changes", "Save changes made to the recipe?", "Save", "Discard"))
+                    DoUpdate();
+                
+                _needsUpdate = false;
+                _forceUpdate = false;
+            }                
+        }
+
 		/// <summary>
 		/// Override PreInspectorGUI in any derived editors to allow editing of new properties added to recipes.
 		/// </summary>
@@ -1781,7 +1799,10 @@ namespace UMA.Editors
 					Rebuild();
 				}
 
-				_needsUpdate = PreInspectorGUI();
+                if (PreInspectorGUI())
+                {
+                    _needsUpdate = true;
+                }
 
 				if (ToolbarGUI())
 				{

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/CharacterBaseEditor.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/CharacterBaseEditor.cs
@@ -1793,12 +1793,7 @@ namespace UMA.Editors
 					_needsUpdate = true;
 				}
 
-                if (_AutomaticUpdates == false)
-                {
-                    _needsUpdate = false;
-                }
-
-                if (_needsUpdate || _forceUpdate)
+                if ((_AutomaticUpdates && _needsUpdate) || _forceUpdate)
 				{
 					DoUpdate();
                     _needsUpdate = false;

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/SlotData.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/SlotData.cs
@@ -37,6 +37,17 @@ namespace UMA
 			overlayScale = asset.overlayScale;
 		}
 
+        /// <summary>
+        /// Property to return overlay hash so it is visible in debugger.
+        /// </summary>
+        public int OverlayHash
+        {
+            get
+            {
+                return GetOverlayList().GetHashCode();
+            }
+        }
+
 		/// <summary>
 		/// Deep copy of the SlotData.
 		/// </summary>
@@ -176,6 +187,16 @@ namespace UMA
 		/// <param name="newOverlayList">The overlay list.</param>
 		public void SetOverlayList(List<OverlayData> newOverlayList)
 		{
+                this.overlayList = newOverlayList;
+		}
+
+        /// <summary>
+        /// Sets the complete list of overlays.
+        /// Reuses the overlay list if it exists.
+        /// </summary>
+        /// <param name="newOverlayList">The overlay list.</param>
+        public void UpdateOverlayList(List<OverlayData> newOverlayList)
+        {
             if (this.overlayList.Count == newOverlayList.Count)
             {
                 // keep the list, and just set the overlays so that merging continues to work.
@@ -326,7 +347,8 @@ namespace UMA
 
 		public void OnAfterDeserialize()
 		{
-			if (overlayList == null) overlayList = new List<OverlayData>();
+			if (overlayList == null)
+                overlayList = new List<OverlayData>();
 		}
 
 		public void OnBeforeSerialize()


### PR DESCRIPTION
Shared Overlays were not working due to an issue with the recipe editor. There were actually two issues - one in a loop that didn't work when there were only 2 slots. Another with the Set function for the overlays reusing the list. (This was a bugfix for the cutout code).