### PR TITLE
Wrapping some code in a try catch to prevent exceptions in some situa…

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/UMAAssetIndexer.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/UMAAssetIndexer.cs
@@ -482,32 +482,39 @@ namespace UMA
         /// <param name="ai"></param>
         private void AddAssetItem(AssetItem ai, bool SkipBundleCheck = false)
         {
-            System.Type theType = TypeToLookup[ai._Type];
-            Dictionary<string, AssetItem> TypeDic = GetAssetDictionary(theType);
-            // Get out if we already have it.
-            if (TypeDic.ContainsKey(ai._Name))
+            try
             {
-                Debug.Log("Duplicate asset " + ai._Name + " was ignored.");
-                return;
-            }
-
-            if (ai._Name.ToLower().Contains((ai._Type.Name+"placeholder").ToLower()))
-            {
-                Debug.Log("Placeholder asset " + ai._Name + " was ignored. Placeholders are not indexed.");
-                return;
-            }
-#if UNITY_EDITOR
-            if (!SkipBundleCheck)
-            {
-                string Path = AssetDatabase.GetAssetPath(ai.Item.GetInstanceID());
-                if (InAssetBundle(Path))
+                System.Type theType = TypeToLookup[ai._Type];
+                Dictionary<string, AssetItem> TypeDic = GetAssetDictionary(theType);
+                // Get out if we already have it.
+                if (TypeDic.ContainsKey(ai._Name))
                 {
-                    Debug.Log("Asset " + ai._Name + "is in Asset Bundle, and was not added to the index.");
+                    Debug.Log("Duplicate asset " + ai._Name + " was ignored.");
                     return;
                 }
-            }
+
+                if (ai._Name.ToLower().Contains((ai._Type.Name + "placeholder").ToLower()))
+                {
+                    Debug.Log("Placeholder asset " + ai._Name + " was ignored. Placeholders are not indexed.");
+                    return;
+                }
+#if UNITY_EDITOR
+                if (!SkipBundleCheck)
+                {
+                    string Path = AssetDatabase.GetAssetPath(ai.Item.GetInstanceID());
+                    if (InAssetBundle(Path))
+                    {
+                        Debug.Log("Asset " + ai._Name + "is in Asset Bundle, and was not added to the index.");
+                        return;
+                    }
+                }
 #endif
-            TypeDic.Add(ai._Name, ai);
+                TypeDic.Add(ai._Name, ai);
+            }
+            catch (System.Exception ex)
+            {
+                UnityEngine.Debug.LogWarning("Exception in UMAAssetIndexer.AddAssetItem: " + ex);
+            }
         }
 
 #if UNITY_EDITOR

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorBuiltin.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorBuiltin.cs
@@ -254,17 +254,24 @@ namespace UMA
 
 		public virtual void OnDirtyUpdate()
 		{
-			if (HandleDirtyUpdate(umaDirtyList[0]))
+			try
 			{
-				umaDirtyList.RemoveAt(0);
-				umaData.MoveToList(cleanUmas);
-				umaData = null;
+				if (HandleDirtyUpdate(umaDirtyList[0]))
+				{
+					umaDirtyList.RemoveAt(0);
+					umaData.MoveToList(cleanUmas);
+					umaData = null;
+				}
+				else if (fastGeneration && HandleDirtyUpdate(umaDirtyList[0]))
+				{
+					umaDirtyList.RemoveAt(0);
+					umaData.MoveToList(cleanUmas);
+					umaData = null;
+				}
 			}
-			else if (fastGeneration && HandleDirtyUpdate(umaDirtyList[0]))
+			catch (Exception ex)
 			{
-				umaDirtyList.RemoveAt(0);
-				umaData.MoveToList(cleanUmas);
-				umaData = null;
+				UnityEngine.Debug.LogWarning("Exception in UMAGeneratorBuiltin.OnDirtyUpdate: " + ex);
 			}
 		}
 


### PR DESCRIPTION
…tions.

The OnDirty() exception typically occurs when loading an avatar for the first time immediately after a scene load.  

The AddAssetItem() exception occurs when attempting to add an animation override controller - I've only seen this have a negative impact in a built client not assigning the correct animator.