### PR TITLE
Proper fix for GetTPoseCorrectedRotation

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorBase.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorBase.cs
@@ -331,7 +331,7 @@ namespace UMA
 				{
 					skeletonbone.position = boneGO.transform.localPosition;
 					skeletonbone.scale = boneGO.transform.localScale;
-					skeletonbone.rotation = umaData.skeleton.GetTPoseCorrectedRotation(boneHash, boneGO.transform.localRotation);
+					skeletonbone.rotation = umaData.skeleton.GetTPoseCorrectedRotation(boneHash, skeletonbone.rotation);
 					newBones.Add(skeletonbone);
 				}
 			}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMASkeleton.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMASkeleton.cs
@@ -660,7 +660,7 @@ namespace UMA
 
 		public virtual Quaternion GetTPoseCorrectedRotation(int nameHash, Quaternion tPoseRotation)
 		{
-			return tPoseRotation;
+			return boneHashData[nameHash].boneTransform.localRotation;
 		}
 	}
 }


### PR DESCRIPTION
This is really a revert of the UMAGeneratorBase.cs and a fix for UMASkeleton.cs.

Power Tools needs the original t-pose rotation to calculate the relative change in order to calculate the proper local rotation in the bone baked skeleton.
