### PR TITLE
webplayer deprecated and cleancache to clearcache

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleManager.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleManager.cs
@@ -187,12 +187,16 @@ namespace UMA.AssetBundles
 		{
 			if (Application.isEditor)
 				return "file://" + System.Environment.CurrentDirectory.Replace("\\", "/"); // Use the build output folder directly.
-			else if (Application.isWebPlayer)
+
+#if !UNITY_2017_2_OR_NEWER
+			if (Application.isWebPlayer)
 				return System.IO.Path.GetDirectoryName(Application.absoluteURL).Replace("\\", "/") + "/StreamingAssets";
-			else if (Application.isMobilePlatform || Application.isConsolePlatform)
+#endif
+			if (Application.isMobilePlatform || Application.isConsolePlatform)
 				return Application.streamingAssetsPath;
-			else // For standalone player.
-				return "file://" + Application.streamingAssetsPath;
+
+			// For standalone player.
+			return "file://" + Application.streamingAssetsPath;
 		}
 
 		/// <summary>

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
@@ -432,7 +432,12 @@ namespace UMA.AssetBundles
 			if (GUILayout.Button(buttonBuildAssetBundlesText))
 			{
 				BuildScript.BuildAssetBundles();
-				Caching.CleanCache ();
+
+#if UNITY_2017_2_OR_NEWER
+				Caching.ClearCache ();
+#else
+				Caching.CleanCache();          
+#endif
 				return;
 			}
 			EndVerticalPadded(5);
@@ -539,7 +544,11 @@ namespace UMA.AssetBundles
 
 				if (GUILayout.Button("Clean the Cache"))
 				{
+#if UNITY_2017_2_OR_NEWER
+					_statusMessage = Caching.ClearCache() ? "Cache Cleared." : "Error clearing cache.";
+#else
 					_statusMessage = Caching.CleanCache() ? "Cache Cleared." : "Error clearing cache.";
+#endif
 				}
 				EditorGUILayout.Space();
 			}


### PR DESCRIPTION
In the GetStreamingAssetsPath, I removed the cascading if else structure because it is unnecessary if each statement is returning right away.  This makes it easier to read and add the directive.  Anyone think otherwise?