### PR TITLE
Fix/uma26/destroyatedittime

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicAssetLoader.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicAssetLoader.cs
@@ -120,7 +120,7 @@ namespace UMA.CharacterSystem
                     _instance.gameObjectsToActivate.Clear();
                     _instance.gameObjectsToActivate.AddRange(this.gameObjectsToActivate);
                     _instance.remoteServerIndexURL = this.remoteServerIndexURL;
-                    Destroy(this.gameObject);
+                    UMAUtils.DestroySceneObject(this.gameObject);
                     destroyingThis = true;
                 }
                 else

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicCharacterAvatar.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicCharacterAvatar.cs
@@ -1855,7 +1855,7 @@ namespace UMA.CharacterSystem
 #endif
 				}
 				if (!saveAsAsset)
-					ScriptableObject.Destroy(asset);
+					UMAUtils.DestroySceneObject(asset);
 			}
 			if (ensureSharedColors)
 			{
@@ -2682,7 +2682,7 @@ namespace UMA.CharacterSystem
 				{
 					foreach (Transform child in gameObject.transform)
 					{
-						Destroy(child.gameObject);
+						UMAUtils.DestroySceneObject(child.gameObject);
 					}
 				}
 				UpdateNewRace();
@@ -2742,7 +2742,7 @@ namespace UMA.CharacterSystem
 
 			foreach (Transform child in gameObject.transform)
 			{
-				Destroy(child.gameObject);
+				UMAUtils.DestroySceneObject(child.gameObject);
 			}
 			ClearSlots();
 			umaRecipe = null;

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicDNAConverterCustomizer.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/DynamicDNAConverterCustomizer.cs
@@ -331,8 +331,8 @@ namespace UMA.CharacterSystem
 				}
 			}
 
-			Destroy(tempAvatarPreDNA);
-			Destroy(tempAvatarPostDNA);
+			UMAUtils.DestroySceneObject(tempAvatarPreDNA);
+			UMAUtils.DestroySceneObject(tempAvatarPostDNA);
 
 			// This can be very helpful for testing
 			/*

--- a/UMAProject/Assets/UMA/Core/Scripts/Editor/UMAAvatarLoadSaveMenuItems.cs
+++ b/UMAProject/Assets/UMA/Core/Scripts/Editor/UMAAvatarLoadSaveMenuItems.cs
@@ -127,7 +127,7 @@ namespace UMA.Editors
                      asset.Save(avatar.umaData.umaRecipe, avatar.context);
                   }				
                   System.IO.File.WriteAllText(path, asset.recipeString);
-                  ScriptableObject.Destroy(asset);
+                  UMAUtils.DestroySceneObject(asset);
                }
             }
          }
@@ -200,7 +200,7 @@ namespace UMA.Editors
                      avatar.Load(asset);
                   }
                   
-                  Destroy(asset);
+                  UMAUtils.DestroySceneObject(asset);
                }
             }
          }

--- a/UMAProject/Assets/UMA/Core/StandardAssets/Extensions/DynamicCharacterSystem/Scripts/pUMAContext.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/Extensions/DynamicCharacterSystem/Scripts/pUMAContext.cs
@@ -36,17 +36,17 @@ namespace UMA
 					//so in this case delete all the components that would have been added from the found gameObject from the previous code
 					if (EditorUMAContext.GetComponent<UMAContext>())
 					{
-						Destroy(EditorUMAContext.GetComponent<UMAContext>());//should also make the instance null again
+						UMAUtils.DestroySceneObject(EditorUMAContext.GetComponent<UMAContext>());//should also make the instance null again
 						if (EditorUMAContext.GetComponent<DynamicRaceLibrary>())
-							Destroy(EditorUMAContext.GetComponent<DynamicRaceLibrary>());
+							UMAUtils.DestroySceneObject(EditorUMAContext.GetComponent<DynamicRaceLibrary>());
 						if (EditorUMAContext.GetComponent<DynamicSlotLibrary>())
-							Destroy(EditorUMAContext.GetComponent<DynamicSlotLibrary>());
+							UMAUtils.DestroySceneObject(EditorUMAContext.GetComponent<DynamicSlotLibrary>());
 						if (EditorUMAContext.GetComponent<DynamicOverlayLibrary>())
-							Destroy(EditorUMAContext.GetComponent<DynamicOverlayLibrary>());
+							UMAUtils.DestroySceneObject(EditorUMAContext.GetComponent<DynamicOverlayLibrary>());
 						if (EditorUMAContext.GetComponent<DynamicCharacterSystem>())
-							Destroy(EditorUMAContext.GetComponent<DynamicCharacterSystem>());
+							UMAUtils.DestroySceneObject(EditorUMAContext.GetComponent<DynamicCharacterSystem>());
 						if (EditorUMAContext.GetComponent<DynamicAssetLoader>())
-							Destroy(EditorUMAContext.GetComponent<DynamicAssetLoader>());
+							UMAUtils.DestroySceneObject(EditorUMAContext.GetComponent<DynamicAssetLoader>());
 					}
 				}
 				else if (UMAContext.FindInstance().gameObject.transform.parent.gameObject.name == "UMAEditorContext")

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMADNAToBonePoseWindow.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMADNAToBonePoseWindow.cs
@@ -174,8 +174,8 @@ namespace UMA.PoseTools
 			}
 			else
 			{
-				Destroy(tempAvatarPreDNA);
-				Destroy(tempAvatarPostDNA);
+				UMAUtils.DestroySceneObject(tempAvatarPreDNA);
+				UMAUtils.DestroySceneObject(tempAvatarPostDNA);
 
 				// Build a prefab DNA Converter and populate it with the morph set
 				string assetName = "Morph Set";

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMAObjExporter.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMAObjExporter.cs
@@ -68,7 +68,7 @@ namespace UMA.Editors
 						var staticMesh = new Mesh();
 						avatar.umaData.GetRenderer(0).BakeMesh(staticMesh);
 						FileUtils.WriteAllText(path, MeshToString(staticMesh, avatar.umaData.GetRenderer(0).sharedMaterials));
-						Object.Destroy(staticMesh);
+						UMAUtils.DestroySceneObject(staticMesh);
 					}
 				}
 			}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAAvatarBase.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAAvatarBase.cs
@@ -143,7 +143,7 @@ namespace UMA
 				umaData.CleanTextures();
 				umaData.CleanMesh(true);
 				umaData.CleanAvatar();
-				Destroy(umaData.umaRoot);
+				UMAUtils.DestroySceneObject(umaData.umaRoot);
 				umaData.umaRoot = null;
 				umaData.SetRenderers(null);
 				umaData.animator = null;

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAData.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAData.cs
@@ -1079,7 +1079,7 @@ namespace UMA
 				CleanTextures();
 				CleanMesh(true);
 				CleanAvatar();
-				Destroy(umaRoot);
+				UMAUtils.DestroySceneObject(umaRoot);
 			}
 		}
 
@@ -1091,8 +1091,8 @@ namespace UMA
 			animationController = null;
 			if (animator != null)
 			{
-				if (animator.avatar) GameObject.Destroy(animator.avatar);
-				if (animator) GameObject.Destroy(animator);
+				if (animator.avatar) UMAUtils.DestroySceneObject(animator.avatar);
+				if (animator) UMAUtils.DestroySceneObject(animator);
 			}
 		}
 
@@ -1114,12 +1114,11 @@ namespace UMA
 							{
 								RenderTexture tempRenderTexture = tempTexture as RenderTexture;
 								tempRenderTexture.Release();
-								Destroy(tempRenderTexture);
-								tempRenderTexture = null;
+								UMAUtils.DestroySceneObject(tempRenderTexture);
 							}
 							else
 							{
-								Destroy(tempTexture);
+								UMAUtils.DestroySceneObject(tempTexture);
 							}
 							generatedMaterials.materials[atlasIndex].resultingAtlasList[textureIndex] = null;
 						}
@@ -1142,13 +1141,13 @@ namespace UMA
 				{
 					if (mats[i])
 					{
-						Destroy(mats[i]);
+						UMAUtils.DestroySceneObject(mats[i]);
 					}
 				}
 				if (destroyRenderer)
 				{
-					Destroy(renderer.sharedMesh);
-					Destroy(renderer);
+					UMAUtils.DestroySceneObject(renderer.sharedMesh);
+					UMAUtils.DestroySceneObject(renderer);
 				}
 			}
 		}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMADefaultMeshCombiner.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMADefaultMeshCombiner.cs
@@ -73,7 +73,7 @@ namespace UMA
 					{
 						for (int i = umaData.generatedMaterials.rendererCount; i < oldRenderers.Length; i++)
 						{
-                            Destroy(oldRenderers[i].gameObject);
+                            UMAUtils.DestroySceneObject(oldRenderers[i].gameObject);
                             //For cloth, be aware of issue: 845868
                             //https://issuetracker.unity3d.com/issues/cloth-repeatedly-destroying-objects-with-cloth-components-causes-a-crash-in-unity-cloth-updatenormals
 						}
@@ -160,7 +160,7 @@ namespace UMA
 				}
 				else
 				{
-					Destroy(cloth);
+					UMAUtils.DestroySceneObject(cloth);
 				}
 
 				var materials = combinedMaterialList.ToArray();

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorBase.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorBase.cs
@@ -172,7 +172,7 @@ namespace UMA
 					{
 						AnimatorState snapshot = new AnimatorState();
 						snapshot.SaveAnimatorState(animator);
-						Object.Destroy(animator.avatar);
+						UMAUtils.DestroySceneObject(animator.avatar);
 						SetAvatar(umaData, animator);
 						if(animator.runtimeAnimatorController != null)
 							snapshot.RestoreAnimatorState(animator);

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorCoroutine.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorCoroutine.cs
@@ -253,7 +253,7 @@ namespace UMA
 					{
 						if (atlasses[i].renderer == j)
 						{
-							UnityEngine.Object.Destroy(mats[materialIndex]);
+							UMAUtils.DestroySceneObject(mats[materialIndex]);
 							newMats[materialIndex] = atlasses[i].material;
 							materialIndex++;
 						}
@@ -279,12 +279,12 @@ namespace UMA
 					{
 						RenderTexture tempRenderTexture = tempTexture as RenderTexture;
 						tempRenderTexture.Release();
-						UnityEngine.Object.Destroy(tempRenderTexture);
+						UMAUtils.DestroySceneObject(tempRenderTexture);
 						tempRenderTexture = null;
 					}
 					else
 					{
-						UnityEngine.Object.Destroy(tempTexture);
+						UMAUtils.DestroySceneObject(tempTexture);
 					}
 					backUpTexture[textureIndex] = null;
 				}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAUtils.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAUtils.cs
@@ -41,7 +41,22 @@ namespace UMA
             }
             return "";
         }
-		
+
+		public static void DestroySceneObject(UnityEngine.Object obj)
+		{
+#if UNITY_EDITOR
+			if (Application.isPlaying)
+			{
+				UnityEngine.Object.Destroy(obj);
+			}
+			else
+			{
+				UnityEngine.Object.DestroyImmediate(obj, false);
+			}
+#else
+			UnityEngine.Object.Destroy(obj);
+#endif
+		}
 	}
 
 	// Extension class for System.Collections.Generic.List<T> to get

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/AvailableColorsHandler.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/AvailableColorsHandler.cs
@@ -66,7 +66,7 @@ namespace UMA.CharacterSystem.Examples
         {
             foreach (Transform t in ColorPanel.transform)
             {
-                GameObject.Destroy(t.gameObject);
+                UMAUtils.DestroySceneObject(t.gameObject);
             }
         }
     }

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/DNAHandler.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/DNAHandler.cs
@@ -30,7 +30,7 @@ namespace UMA.CharacterSystem.Examples
             {
                 foreach (Transform t in SelectionPanel.transform)
                 {
-                    GameObject.Destroy(t.gameObject);
+                    UMAUtils.DestroySceneObject(t.gameObject);
                 }
             }
         }

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/SampleCode.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/SampleCode.cs
@@ -39,11 +39,11 @@ namespace UMA.CharacterSystem.Examples
 
             foreach (Transform t in SlotPanel.transform)
             {
-                GameObject.Destroy(t.gameObject);
+                UMAUtils.DestroySceneObject(t.gameObject);
             }
             foreach (Transform t in WardrobePanel.transform)
             {
-                GameObject.Destroy(t.gameObject);
+                UMAUtils.DestroySceneObject(t.gameObject);
             }
         }
 

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/SlotHandler.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Assets/Resources/Scene1/SlotHandler.cs
@@ -69,7 +69,7 @@ namespace UMA.CharacterSystem.Examples
             {
                 foreach (Transform t in WardrobePanel.transform)
                 {
-                    GameObject.Destroy(t.gameObject);
+                    UMAUtils.DestroySceneObject(t.gameObject);
                 }
             }
         }

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Scripts/DNAPanel.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Scripts/DNAPanel.cs
@@ -40,7 +40,7 @@ namespace UMA.CharacterSystem
 	public void Initialize (DynamicCharacterAvatar Avatar) 
 		{
 
-		foreach(GameObject go in CreatedObjects) Destroy(go);
+		foreach(GameObject go in CreatedObjects) UMAUtils.DestroySceneObject(go);
 		CreatedObjects.Clear();
 
 			UMADnaBase[] DNA = Avatar.GetAllDNA();

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Assets/AdditionalSlots/Expressions/ExpressionSlotScript.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Assets/AdditionalSlots/Expressions/ExpressionSlotScript.cs
@@ -46,7 +46,7 @@ namespace UMA.PoseTools
 			var expressionPlayer = umaData.GetComponent<UMAExpressionPlayer>();
 			if (expressionPlayer.SlotUpdateVsCharacterUpdate-- == 0)
 			{
-				Destroy(expressionPlayer);
+				UMAUtils.DestroySceneObject(expressionPlayer);
 				umaData.CharacterUpdated.RemoveListener(new UnityAction<UMAData>(umaData_OnCharacterUpdated));
 				return;
 			}

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMACharacterCustomization.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMACharacterCustomization.cs
@@ -136,7 +136,7 @@ namespace UMA.Examples
 
         public void ButtonMale()
         {
-            Destroy(GameObject.Find("UMACrowd").transform.GetChild(0).gameObject);
+            UMAUtils.DestroySceneObject(GameObject.Find("UMACrowd").transform.GetChild(0).gameObject);
             crowdHandle.ResetSpawnPos();
             GameObject myUma = crowdHandle.GenerateOneUMA(0);
             myUma.transform.localRotation = Quaternion.Euler(new Vector3(0, 180, 0));
@@ -155,7 +155,7 @@ namespace UMA.Examples
 
         public void ButtonFemale()
         {
-            Destroy(GameObject.Find("UMACrowd").transform.GetChild(0).gameObject);
+            UMAUtils.DestroySceneObject(GameObject.Find("UMACrowd").transform.GetChild(0).gameObject);
             crowdHandle.ResetSpawnPos();
             GameObject myUma = crowdHandle.GenerateOneUMA(1);
             myUma.transform.localRotation = Quaternion.Euler(new Vector3(0, 180, 0));

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMACrowd.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMACrowd.cs
@@ -659,7 +659,7 @@ namespace UMA.Examples
 			while(--childCount >= 0)
 			{
 				Transform child = gameObject.transform.GetChild(childCount);
-				Destroy(child.gameObject);
+				UMAUtils.DestroySceneObject(child.gameObject);
 			}
 
 			if (umaCrowdSize.x <= 1 && umaCrowdSize.y <= 1)

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMARecipeCrowd.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMARecipeCrowd.cs
@@ -169,7 +169,7 @@ namespace UMA.Examples
 			while(--childCount >= 0)
 			{
 				Transform child = gameObject.transform.GetChild(childCount);
-				Destroy(child.gameObject);
+				UMAUtils.DestroySceneObject(child.gameObject);
 			}
 
 			generating = true;

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMARemoveComponents.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMARemoveComponents.cs
@@ -16,7 +16,7 @@ namespace UMA.Examples
 			foreach (var componentName in removeComponentNames)
 			{
 				var component = data.animator.GetComponent(componentName);
-				Destroy(component);
+				UMAUtils.DestroySceneObject(component);
 			}
 			foreach (var componentName in disableComponentNames)
 			{

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMASlotVerifyWizard.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMASlotVerifyWizard.cs
@@ -82,7 +82,7 @@ namespace UMA.Examples
 				}
 				else
 				{
-					Destroy(RaceGO);
+					UMAUtils.DestroySceneObject(RaceGO);
 				}
 			}
 		}
@@ -120,7 +120,7 @@ namespace UMA.Examples
 				}
 				else
 				{
-					Destroy(SlotGO);
+					UMAUtils.DestroySceneObject(SlotGO);
 				}
 			}
 		}
@@ -153,19 +153,19 @@ namespace UMA.Examples
 		{
 			if (forcedSlotBones)
 			{
-				Destroy(SlotGO);
+				UMAUtils.DestroySceneObject(SlotGO);
 				SlotGO = Instantiate(slotAsset) as GameObject;
 				SlotSMR = SlotGO.GetComponentInChildren<SkinnedMeshRenderer>();
 				forcedSlotBones = false;
 			}
-			Destroy(RaceGO);
+			UMAUtils.DestroySceneObject(RaceGO);
 			SetPage(0);
 		}
 
 		public void SelectNewSlotMesh()
 		{
 			forcedSlotBones = false;
-			Destroy(SlotGO);
+			UMAUtils.DestroySceneObject(SlotGO);
 			SetPage(1);
 		}
 


### PR DESCRIPTION
I've made a cleanup pass where I've replaced most UnityEngine.Object.Destroy( ) calls to a UMAUtils.DestroySceneObject( ) call instead. This takes care of calling DestroyImmediate( , false) if not in playmode. I skipped a few instances in DCS because it wasn't immediately apparent if there would be side effects.


This allows me to clean up some code in my power tools editor preview and should help us migrate towards a future where we can have uma editor time