### PR TITLE
Restores some editor functionality to text recipes

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/UMAWardrobeCollectionEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/UMAWardrobeCollectionEditor.cs
@@ -437,7 +437,7 @@ namespace UMA.Editors
 			EditorGUILayout.Space();
 			//Draw the Wardrobe slot field as a WardrobeCollection Group text field.
 			EditorGUILayout.HelpBox("When a collection is placed on an avatar it replaces any other collections belonging to this group and unloads that collections recipes", MessageType.Info);
-            var newWardrobeSlot = EditorGUILayout.TextField("Collection Group", wardrobeSlot);
+            var newWardrobeSlot = EditorGUILayout.DelayedTextField("Collection Group", wardrobeSlot);
 			if(newWardrobeSlot != wardrobeSlot)
 			{
 				WardrobeSlotField.SetValue(target, newWardrobeSlot);

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/pDCSRecipeEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/pDCSRecipeEditor.cs
@@ -20,6 +20,7 @@ namespace UMA.Editors
 			private string _wsRace;
 			private string _wsSlot;
 			private string _wsRecipeName;
+			private string _wcOverrideName;
 			Texture warningIcon;
 
 			public string RecipeName
@@ -29,11 +30,12 @@ namespace UMA.Editors
 					return _wsRecipeName;
 				}
 			}
-			public WardrobeSlotRecipePopup(string race, string slot, string recipeName)
+			public WardrobeSlotRecipePopup(string race, string slot, string recipeName, string wcOverrideName = "")
 			{
 				_wsRace = race;
 				_wsSlot = slot;
 				_wsRecipeName = recipeName;
+				_wcOverrideName = wcOverrideName;
 			}
 
 			public bool OnGUI()
@@ -52,7 +54,13 @@ namespace UMA.Editors
 				var recipesForRaceSlot = context.dynamicCharacterSystem.GetRecipeNamesForRaceSlot(_wsRace, _wsSlot);
 				List<string> thisPopupVals = new List<string>();
 				thisPopupVals.Add("None");
+				List<string> thisPopupLabels = new List<string>();
+				var noneString = "None";
+				if (_wcOverrideName != "")
+					noneString = "None (Set by '" + _wcOverrideName + "' Wardrobe Collection)";
+				thisPopupLabels.Add(noneString);
 				thisPopupVals.AddRange(recipesForRaceSlot);
+				thisPopupLabels.AddRange(recipesForRaceSlot);
 				var selected = 0;
 				var recipeIsLive = true;
 				Rect valRBut = new Rect();
@@ -69,15 +77,15 @@ namespace UMA.Editors
 						string missingOrIncompatible = "missing";
 						if (context.dynamicCharacterSystem.GetBaseRecipe(_wsRecipeName, false) != null)
 							missingOrIncompatible = "incompatible";
-						thisPopupVals.Add(_wsRecipeName + " (" + missingOrIncompatible + ")");
-					}
+						thisPopupLabels.Add(_wsRecipeName + " (" + missingOrIncompatible + ")");
+                    }
 				}
 				var newSelected = selected;
 				if (!recipeIsLive)
 					EditorGUI.indentLevel++;
 				var label = _wsSlot == "WardrobeCollection" ? " " : _wsSlot;
 				EditorGUI.BeginChangeCheck();
-				newSelected = EditorGUILayout.Popup(label, selected, thisPopupVals.ToArray());
+				newSelected = EditorGUILayout.Popup(label, selected, thisPopupLabels.ToArray());
 				if (!recipeIsLive)
 				{
 					EditorGUI.indentLevel--;
@@ -88,7 +96,7 @@ namespace UMA.Editors
 					if (newSelected != selected)
 					{
 						changed = true;
-						_wsRecipeName = (thisPopupVals[newSelected].IndexOf("(missing)") == -1 && thisPopupVals[newSelected].IndexOf("(incompatible)") == -1) ? (thisPopupVals[newSelected] != "None" ? thisPopupVals[newSelected] : "") : _wsRecipeName.Replace("(missing)", "").Replace("(incompatible)", "");
+						_wsRecipeName = (thisPopupLabels[newSelected].IndexOf("(missing)") == -1 && thisPopupLabels[newSelected].IndexOf("(incompatible)") == -1) ? (thisPopupVals[newSelected] != "None" ? thisPopupVals[newSelected] : "") : _wsRecipeName;
 					}
 				}
 				if (!recipeIsLive)
@@ -148,12 +156,20 @@ namespace UMA.Editors
 						if (_wardrobeSet == null || context == null)
 							return false;
 						GUIHelper.BeginVerticalPadded(10, new Color(0.75f, 0.875f, 1f));
+
+						EditorGUILayout.HelpBox("Recently added recipes not showing up? Make sure you have added them to the 'UMA Global Library' and click the 'Refresh Recipes' button below.", MessageType.Info);
+						if (GUILayout.Button("Refresh Recipes"))
+						{
+							context.dynamicCharacterSystem.Refresh(false);
+							return false;
+						}
+						//a dictionary of slots that are being assigned by WardrobeCollections
+						var slotsAssignedByWCs = new Dictionary<string, string>();
 						if (_allowWardrobeCollectionSlot)
 						{
 							var wcRecipesForRace = context.dynamicCharacterSystem.GetRecipesForRaceSlot(_race.raceName, "WardrobeCollection");
-							var wcGroupDict = new Dictionary<string, List<string>>();
-							//for 'Standard Assets' we need to do some kind of get Types thing I think because we then need to use reflection to get the wardrobeSlot field
-							//how can we get what we want here when WardrobeCollections dont exist in Standard Assets (if 'StandardAssets' has been moved there)
+							var wcGroupDict = new Dictionary<string, List<UMARecipeBase>>();
+							//I'm using reflection here to get fields and methods from the UMAWardrobeCollection type so this will still work if 'StandardAssets' is moved to 'Standard Assets'
 							for (int i = 0; i < wcRecipesForRace.Count; i++)
 							{
 								Type wcType = wcRecipesForRace[i].GetType();
@@ -163,31 +179,42 @@ namespace UMA.Editors
 									var wcRecipeSlot = (string)wcRecipeSlotField.GetValue(wcRecipesForRace[i]);
 									if (!wcGroupDict.ContainsKey(wcRecipeSlot))
 									{
-										wcGroupDict.Add(wcRecipeSlot, new List<string>());
+										wcGroupDict.Add(wcRecipeSlot, new List<UMARecipeBase>());
 									}
-									wcGroupDict[wcRecipeSlot].Add(wcRecipesForRace[i].name);
+									wcGroupDict[wcRecipeSlot].Add(wcRecipesForRace[i]);
 								}
 							}
 							if (wcGroupDict.Count > 0)
 							{
+								MethodInfo WCGetRacesWardrobeSetMethod = null;
 								EditorGUILayout.LabelField("WardrobeCollections");
 								EditorGUI.indentLevel++;
-								foreach (KeyValuePair<string, List<string>> kp in wcGroupDict)
+								foreach (KeyValuePair<string, List<UMARecipeBase>> kp in wcGroupDict)
 								{
-									var thisPopupVals = new List<string>();
-									thisPopupVals.Add("None");
-									thisPopupVals.AddRange(kp.Value);
+									if (WCGetRacesWardrobeSetMethod == null)
+										WCGetRacesWardrobeSetMethod = kp.Value[0].GetType().GetMethod("GetRacesWardrobeSet", new Type[] { typeof(RaceData) });
 									var selected = 0;
 									var prevRecipe = "";
-									//if one of the recipes in the wardrobe set is one of these then its selected
-									for (int pvi = 0; pvi < thisPopupVals.Count; pvi++)
+									var thisPopupVals = new List<string>();
+									thisPopupVals.Add("None");
+									for (int i = 0; i < kp.Value.Count; i++)
 									{
+										thisPopupVals.Add(kp.Value[i].name);
+										//check if this is selected
 										for (int wsi = 0; wsi < _wardrobeSet.Count; wsi++)
 										{
-											if (thisPopupVals[pvi] == _wardrobeSet[wsi].recipe)
+											if (kp.Value[i].name == _wardrobeSet[wsi].recipe)
 											{
 												prevRecipe = _wardrobeSet[wsi].recipe;
-												selected = pvi;
+												selected = i + 1;
+												var thisWCWardrobeSet = (List<WardrobeSettings>)WCGetRacesWardrobeSetMethod.Invoke(kp.Value[i], new object[] { _race });
+												for (int wcwsi = 0; wcwsi < thisWCWardrobeSet.Count; wcwsi++)
+												{
+													if (!slotsAssignedByWCs.ContainsKey(thisWCWardrobeSet[wcwsi].slot))
+														slotsAssignedByWCs.Add(thisWCWardrobeSet[wcwsi].slot, kp.Value[i].name);
+													else
+														slotsAssignedByWCs[thisWCWardrobeSet[wcwsi].slot] = kp.Value[i].name;
+												}
 												break;
 											}
 										}
@@ -226,8 +253,9 @@ namespace UMA.Editors
 							if (wsl == "None")
 								continue;
 
-							if (wsl == "FullOutfit" && _allowWardrobeCollectionSlot == false)
-								continue;
+							//Obsolete- now wardrobeCollections apply their WardrobeSet to any slots
+							//if (wsl == "FullOutfit" && _allowWardrobeCollectionSlot == false)
+							//	continue;
 
 							WardrobeSlotRecipePopup thisPicker = null;
 							bool assignedPicker = false;
@@ -242,6 +270,10 @@ namespace UMA.Editors
 							}
 							if (!assignedPicker)//means there was nothing in the wardrobe set for it
 							{
+								//This may still be being assigned by a wardrobe collection though so show that
+								var wcOverrideName = "";
+								if (slotsAssignedByWCs.ContainsKey(wsl))
+									wcOverrideName = slotsAssignedByWCs[wsl];
 								thisPicker = new WardrobeSlotRecipePopup(_race.raceName, wsl, "");
 							}
 							if (thisPicker.OnGUI())
@@ -394,6 +426,7 @@ namespace UMA.Editors
 					{
 						EditorGUI.BeginDisabledGroup(true);
 						GUIHelper.BeginVerticalPadded(10, new Color(0.75f, 0.875f, 1f));
+						EditorGUILayout.HelpBox("If you are going to use the recipe with a DynamicCharacterAvatar, it is recommended that you that you edit the 'WardrobeSet' section above and/or the base/wardrobe recipes directly. Changes you make manually below will only affect old style UMAAvatars", MessageType.Info);
 						for (int i = 0; i < _slotEditors.Count; i++)
 						{
 							var editor = _slotEditors[i];
@@ -441,7 +474,7 @@ namespace UMA.Editors
 						{
 							if (_wardrobeSet == null)
 								return false;
-							//if this is a 'backwards compatible' recipe dont show the 'wardrobeCollections' bit
+							//if this is a 'backwards compatible' recipe dont show the 'wardrobeCollections' bit since old avatars cannot wear collections
 							bool showWardrobeCollections = _recipe.slotDataList.Length > 0 ? false : true;
                             var thisWardrobeSetEditor = new WardrobeSetEditor(_recipe.raceData, _wardrobeSet, _recipe, showWardrobeCollections);
 							if (thisWardrobeSetEditor.OnGUI())
@@ -486,7 +519,7 @@ namespace UMA.Editors
 						{
 							continue;
 						}
-						if (thisRecipe.GetType().ToString() == "UMAWardrobeCollection")
+						if (thisRecipe.GetType().ToString() == "UMA.UMAWardrobeCollection")
 						{
 							var TargetType = thisRecipe.GetType();
 							FieldInfo WardrobeCollectionField = TargetType.GetField("wardrobeCollection", BindingFlags.Public | BindingFlags.Instance);

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/pTextRecipeEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/pTextRecipeEditor.cs
@@ -21,6 +21,9 @@ namespace UMA.Editors
 		protected List<string> generatedBaseSlotOptions = new List<string>();
 		protected List<string> generatedBaseSlotOptionsLabels = new List<string>();
 
+		FieldInfo ActiveWardrobeSetField = null;
+		List<WardrobeSettings> activeWardrobeSet = null;
+
 		protected override bool PreInspectorGUI()
 		{
 			return TextRecipeGUI();
@@ -128,7 +131,8 @@ namespace UMA.Editors
 							if (DnaConverter != null)
 							{
 								DNAConvertersAdded = true;
-								_recipe.AddDNAUpdater(DnaConverter);
+								//the recipe already has the DNAConverter, it just doesn't have the values it requires to show the output in the DNA tab of the recipe
+								//_recipe.AddDNAUpdater(DnaConverter);
 								Type thisType = DnaConverter.DNAType;
 								if (DnaConverter is DynamicDNAConverterBehaviourBase)
 								{
@@ -273,57 +277,37 @@ namespace UMA.Editors
 
 		private bool TextRecipeGUI()
 		{
-			Type TargetType = target.GetType();
+			Type TargetType = target.GetType();//used to get the UMATextRecipe type taher than UMARecipeBase
 			bool doUpdate = false;
 
-			if (TargetType.ToString() == "UMATextRecipe" /*|| TargetType.ToString() == "UMAWardrobeRecipe" || TargetType.ToString() == "UMADCSRecipe"*/)
+			if (TargetType.ToString() == "UMA.UMATextRecipe")
 			{
-				FieldInfo RecipeTypeField = TargetType.GetField("recipeType", BindingFlags.Public | BindingFlags.Instance);
-				//the Recipe Type field defines whether the extra wardrobe recipe fields show and whether we are overriding the SlotMasterEditor with WardrobeSetMasterEditor
-				string recipeType = (string)RecipeTypeField.GetValue(target);
-
-				FieldInfo ActiveWardrobeSetField = TargetType.GetField("activeWardrobeSet", BindingFlags.Public | BindingFlags.Instance);
-				List<WardrobeSettings> activeWardrobeSet = (List<WardrobeSettings>)ActiveWardrobeSetField.GetValue(target);
-
-				//if this recipeType == Wardrobe the recipe is old, i.e. from before they were seperate type, so show a warning
-				if (recipeType == "WardrobeCollection" || recipeType == "DynamicCharacterAvatar" || recipeType == "Wardrobe")
-				{
-					EditorGUILayout.HelpBox("This is an out of date " + recipeType + " recipe. Please recreate it by creating a new one from the 'Create/UMA/DCS' menu", MessageType.Warning);
-					hideRaceField = true;
-					hideToolBar = true;
-				}
 
 				EditorGUI.BeginDisabledGroup(true);
 
-				if (!recipeTypeOpts.Contains(recipeType))
-					recipeTypeOpts.Add(recipeType);
-
-				int rtIndex = recipeTypeOpts.IndexOf(recipeType);
-				EditorGUILayout.Popup("Recipe Type", rtIndex, recipeTypeOpts.ToArray());
+				EditorGUILayout.Popup("Recipe Type", 0, new string[] { "Standard" });//other types (WardrobeRecipe, DynamicCharacterAvatarRecipe) have their own editors now so this is just for UI consistancy
 
 				EditorGUI.EndDisabledGroup();
 
-				//If this is a Standard recipe or a DynamicCharacterAvatar we may need to fix or update the DNA converters
-				//This happens when the race the recipe uses has a DNA converter that has been changed from UMADNAHumanoid to DynamicDNA
-				if (recipeType == "Standard" || recipeType == "DynamicCharacterAvatar")
+				if (ActiveWardrobeSetField == null)
+					ActiveWardrobeSetField = TargetType.GetField("activeWardrobeSet", BindingFlags.Public | BindingFlags.Instance);
+				List<WardrobeSettings> activeWardrobeSet = (List<WardrobeSettings>)ActiveWardrobeSetField.GetValue(target);
+				//draws a button to 'Add DNA' when a new 'standard' recipe is created
+				if (AddDNAButtonUI())
 				{
-					//draws a button to 'Add DNA' when a new 'standard' recipe is created
-					if (AddDNAButtonUI())
-					{
-						hideToolBar = false;
-						return true;
-					}
-					//fixes dna when the recipes race has updated from UMADnaHumanoid/Tutorial to DynamicDna
-					if (FixDNAConverters())
-					{
-						hideToolBar = false;
-						return true;
-					}
+					hideToolBar = false;
+					return true;
+				}
+				//fixes dna when the recipes race has updated from UMADnaHumanoid/Tutorial to DynamicDna
+				if (FixDNAConverters())
+				{
+					hideToolBar = false;
+					return true;
 				}
 
 				//When recipes are saved from a DynamicCharacterAvatar as a 'Standard' rather than 'Optimized' recipe they are saved as 'BackwardsCompatible'
 				//This means they have slots/overlay data AND a wardrobeSet. In this case we need to draw the "DynamicCharacterAvatarRecipe' slot editor
-				//and this will show an editable Wardrobe set which will update an (uneditable) slot/overlay list
+				//and this will show an editable Wardrobe set which will update and a slot/overlay list
 				if ((activeWardrobeSet.Count > 0))
 				{
 					hideRaceField = false;


### PR DESCRIPTION
This is maybe features now since they have been absent for so long, but you know...

Puts the 'Add DNA…' button back when you create a new TextRecipe and assign a race. Shows the 'Backwards Compatibility' section when you save a DCA as 'Backwards Compatible' eg shows the 'wardrobe Set' and the standard recipe that non DCA's will use (greyed out)

Adds a 'Refresh Recipes' button (with help) that refreshes the dropdowns with anything that might have recently been added to the Global Library.
Adds some improvements to WardrobeCollections UI that makes them all show up according to their collection name in the 'WardrobeCollections' section of a DCA recipe.