### PR TITLE
UMAAssetBundleManager Improvements:

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleIndex.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleIndex.cs
@@ -126,6 +126,12 @@ namespace UMA.AssetBundles
 		public List<AssetBundleIndexList> bundlesIndex = new List<AssetBundleIndexList>();
 		[SerializeField]
 		public string[] bundlesWithVariant;
+		/// <summary>
+		/// You can make sure this value is set by checking 'Enable Bundle Index Versioning' in the UMA AssetBundles Settings window.
+		/// You can use it to determine if the assetBundles are compatible with the current application build and vice versa.
+		/// </summary>
+		[SerializeField]
+		public string bundlesPlayerVersion = "";
 
 		public AssetBundleIndex()
 		{
@@ -221,9 +227,10 @@ namespace UMA.AssetBundles
 		public string[] GetAllAssetBundleNames()
 		{
 			List<string> assetBundleNames = new List<string>();
-			foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			//foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			for(int i = 0; i < bundlesIndex.Count; i++)
 			{
-				assetBundleNames.Add(iAssetList.assetBundleName);
+				assetBundleNames.Add(bundlesIndex[i].assetBundleName);
 			}
 			return assetBundleNames.ToArray();
 		}
@@ -337,15 +344,17 @@ namespace UMA.AssetBundles
 		public string[] GetAllAssetsOfTypeInBundle(string assetBundleName, string type)
 		{
 			List<string> foundAssets = new List<string>();
-			foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			//foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			for(int i = 0; i < bundlesIndex.Count; i++)
 			{
-				if (iAssetList.assetBundleName == assetBundleName)
+				if (bundlesIndex[i].assetBundleName == assetBundleName)
 				{
-					foreach (AssetBundleIndexItem iAsset in iAssetList.assetBundleAssets)
+					//foreach (AssetBundleIndexItem iAsset in iAssetList.assetBundleAssets)
+					for(int ii = 0; ii < bundlesIndex[i].assetBundleAssets.Count; ii++)
 					{
-						if (type == "" || (type != "" && (type == iAsset.assetType || type == GetTypeWithoutAssembly(iAsset.assetType))))
+						if (type == "" || (type != "" && (type == bundlesIndex[i].assetBundleAssets[ii].assetType || type == GetTypeWithoutAssembly(bundlesIndex[i].assetBundleAssets[ii].assetType))))
 						{
-							foundAssets.Add(iAsset.assetName);
+							foundAssets.Add(bundlesIndex[i].assetBundleAssets[ii].assetName);
 						}
 
 					}
@@ -357,27 +366,29 @@ namespace UMA.AssetBundles
 		public AssetBundleIndexItem GetAssetBundleIndexItem(string assetBundleName, string assetNameOrFilename, string type = "")
 		{
 			AssetBundleIndexItem indexAsset = null;
-			foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			//foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			for(int i = 0; i < bundlesIndex.Count; i++)
 			{
 				if (indexAsset != null)
 					break;
-				if (iAssetList.assetBundleName == assetBundleName)
+				if (bundlesIndex[i].assetBundleName == assetBundleName)
 				{
-					foreach (AssetBundleIndexItem iAsset in iAssetList.assetBundleAssets)
+					//foreach (AssetBundleIndexItem iAsset in bundlesIndex[i].assetBundleAssets)
+					for(int ii = 0; ii < bundlesIndex[i].assetBundleAssets.Count; ii++)
 					{
-						if (assetNameOrFilename == iAsset.assetName)
+						if (assetNameOrFilename == bundlesIndex[i].assetBundleAssets[ii].assetName)
 						{
-							if (type == "" || (type != "" && (type == iAsset.assetType || type == GetTypeWithoutAssembly(iAsset.assetType))))
+							if (type == "" || (type != "" && (type == bundlesIndex[i].assetBundleAssets[ii].assetType || type == GetTypeWithoutAssembly(bundlesIndex[i].assetBundleAssets[ii].assetType))))
 							{
-								indexAsset = iAsset;
+								indexAsset = bundlesIndex[i].assetBundleAssets[ii];
 							}
 
 						}
-						else if (assetNameOrFilename == iAsset.filename)
+						else if (assetNameOrFilename == bundlesIndex[i].assetBundleAssets[ii].filename)
 						{
-							if (type == "" || (type != "" && (type == iAsset.assetType || type == GetTypeWithoutAssembly(iAsset.assetType))))
+							if (type == "" || (type != "" && (type == bundlesIndex[i].assetBundleAssets[ii].assetType || type == GetTypeWithoutAssembly(bundlesIndex[i].assetBundleAssets[ii].assetType))))
 							{
-								indexAsset = iAsset;
+								indexAsset = bundlesIndex[i].assetBundleAssets[ii];
 							}
 
 						}
@@ -392,19 +403,21 @@ namespace UMA.AssetBundles
 		public AssetBundleIndexItem GetAssetBundleIndexItem(string assetBundleName, int? assetNameHash, string type = "")
 		{
 			AssetBundleIndexItem indexAsset = null;
-			foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			//foreach (AssetBundleIndexList iAssetList in bundlesIndex)
+			for(int i = 0; i < bundlesIndex.Count; i++)
 			{
 				if (indexAsset != null)
 					break;
-				if (iAssetList.assetBundleName == assetBundleName)
+				if (bundlesIndex[i].assetBundleName == assetBundleName)
 				{
-					foreach (AssetBundleIndexItem iAsset in iAssetList.assetBundleAssets)
+					//foreach (AssetBundleIndexItem iAsset in iAssetList.assetBundleAssets)
+					for(int ii = 0; ii < bundlesIndex[i].assetBundleAssets.Count; ii++)
 					{
-						if (assetNameHash == iAsset.assetHash)
+						if (assetNameHash == bundlesIndex[i].assetBundleAssets[ii].assetHash)
 						{
-							if (type == "" || (type != "" && (type == iAsset.assetType || type == GetTypeWithoutAssembly(iAsset.assetType))))
+							if (type == "" || (type != "" && (type == bundlesIndex[i].assetBundleAssets[ii].assetType || type == GetTypeWithoutAssembly(bundlesIndex[i].assetBundleAssets[ii].assetType))))
 							{
-								indexAsset = iAsset;
+								indexAsset = bundlesIndex[i].assetBundleAssets[ii];
 							}
 
 						}

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleLoadOperation.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleLoadOperation.cs
@@ -8,6 +8,8 @@ using UnityEngine.iOS;
 using UnityEditor;
 #endif
 using System.Collections;
+//added System.IO for loading/saving cached bundleIndexes
+using System.IO;
 
 namespace UMA.AssetBundles
 {
@@ -251,6 +253,8 @@ namespace UMA.AssetBundles
 		string m_Url;
 		int zeroDownload = 0;
 		bool m_isJsonIndex = false;
+		int retryAttempts = 0;
+		int maxRetryAttempts = 5;
 
 		public AssetBundleDownloadFromWebOperation(string assetBundleName, WWW www, bool isJsonIndex = false)
 			: base(assetBundleName)
@@ -286,22 +290,30 @@ namespace UMA.AssetBundles
 			base.Update();
 			}
             
-			// TODO: When can check iOS copy this into the iOS functions above
+			// TODO: iOS AppSlicing and OnDemandResources will need something like this too
 			// This checks that the download is actually happening and restarts it if it is not
 			//fixes a bug in SimpleWebServer where it would randomly stop working for some reason
 			if (!downloadIsDone)
 			{
-				downloadProgress = m_WWW.progress;
+				//We actually need to know if progress has stalled, not just if there is none
+				//so set the progress after we compare
+				//downloadProgress = m_WWW.progress;
 				if (!string.IsNullOrEmpty(m_WWW.error))
 				{
 					Debug.Log("[AssetBundleLoadOperation] download error for "+ m_WWW.url+" : " + m_WWW.error);
 				}
 				else
 				{
-					if (m_WWW.progress == 0)
+					//if (m_WWW.progress == 0)
+					if(m_WWW.progress == downloadProgress)
 					{
 						zeroDownload++;
 					}
+					else
+					{
+						downloadProgress = m_WWW.progress;
+						zeroDownload = 0;
+                    }
 #if UNITY_EDITOR
 					//Sometimes SimpleWebServer randomly looses it port connection
 					//Sometimes restarting the download helps, sometimes it needs to be completely restarted
@@ -329,12 +341,39 @@ namespace UMA.AssetBundles
 					}
 					else
 #endif
-					if(zeroDownload == 500)
+					if((downloadProgress == 0 && zeroDownload == 500) || zeroDownload >= Mathf.Clamp((2500 * downloadProgress), 500,2500))//let this number get larger the more has been downloaded (cos its really annoying to be at 98% and have it fail)
 					{
-						Debug.Log("[AssetBundleLoadOperation] progress was zero for 500 frames restarting dowload");
+						//when we cannot download because WiFi is connected but a hotspot needs authentication
+						//or because the user has run out of mobile data the www class takes a while error out
+						if ((AssetBundleManager.ConnectionChecker != null && !AssetBundleManager.ConnectionChecker.InternetAvailable) || retryAttempts > maxRetryAttempts)
+						{
+							if (retryAttempts > maxRetryAttempts)
+							{
+								//there was some unknown error with the connection
+								//tell the user we could not complete the download
+								error = "Downloading of " + assetBundleName + " failed after 10 attempts. Something is wrong with the internet connection.";
+								m_WWW.Dispose();
+								m_WWW = null;
+							}
+							else
+							{
+								//if we have a connection checker and no connection, leave the www alone so it times out on its own
+								Debug.Log("[AssetBundleLoadOperation] progress was zero for "+ zeroDownload+" frames and the ConnectionChecker said there was no Internet Available.");
+							}
+						}
+						else
+					{
+							Debug.Log("[AssetBundleLoadOperation] progress was zero for " + zeroDownload + " frames restarting dowload");
 						m_WWW.Dispose();
 						m_WWW = null;
+							//m_WWW = new WWW(m_Url);//make sure this still caches
+							if (AssetBundleManager.AssetBundleIndexObject != null)
+								m_WWW = WWW.LoadFromCacheOrDownload(m_Url, AssetBundleManager.AssetBundleIndexObject.GetAssetBundleHash(assetBundleName), 0);
+							else
 						m_WWW = new WWW(m_Url);
+							//but increment the retry either way so the failed Ui shows sooner
+							retryAttempts++;
+						}
 						zeroDownload = 0;
 					}
 
@@ -343,7 +382,10 @@ namespace UMA.AssetBundles
 			}
 			else
 			{
-				downloadProgress = 1f;
+				if (string.IsNullOrEmpty(error))
+				  downloadProgress = 1f;
+				else
+					downloadProgress = 0;
 				return false;
 			}
 		}
@@ -362,10 +404,11 @@ namespace UMA.AssetBundles
 
 		protected override void FinishDownload()
 		{
-			error = m_WWW.error;
+			if(m_WWW != null)
+			   error = m_WWW.error;
 			if (!string.IsNullOrEmpty(error))
 			{
-				Debug.LogWarning("[AssetBundleLoadOperation.AssetBundleDownloadFromWebOperation] URL was "+ m_WWW.url+" error was " + error);
+				Debug.LogWarning("[AssetBundleLoadOperation.AssetBundleDownloadFromWebOperation] URL was "+ m_Url + " error was " + error);
 				return;
 			}
 
@@ -622,7 +665,7 @@ namespace UMA.AssetBundles
 			LoadedAssetBundle loadedBundle = AssetBundleManager.GetLoadedAssetBundle(m_AssetBundleName, out m_DownloadingError);
 			if (loadedBundle != null)
 			{
-				///@TODO: When asset bundle download fails this throws an exception...
+				/// When asset bundle download fails this throws an exception but this should be caught above now
 				m_Request = loadedBundle.m_AssetBundle.LoadAssetAsync(m_AssetName, m_Type);
 				return false;
 			}
@@ -651,7 +694,8 @@ namespace UMA.AssetBundles
 	/// </summary>
 	public class AssetBundleLoadIndexOperation : AssetBundleLoadAssetOperationFull
 	{
-		bool _isJsonIndex;
+		//made protected so descendent class can inherit
+		protected bool _isJsonIndex;
 		public AssetBundleLoadIndexOperation(string bundleName, string assetName, System.Type type, bool isJsonIndex = false)
 			: base(bundleName, assetName, type)
 		{
@@ -685,6 +729,18 @@ namespace UMA.AssetBundles
 			if (m_Request != null && m_Request.isDone)
             {
                 AssetBundleManager.AssetBundleIndexObject = GetAsset<AssetBundleIndex>();
+				//If there is an AssetBundleManager.m_ConnectionChecker and it is set to m_ConnectionChecker.UseBundleIndexCaching
+				//cache this so we can use it offline if we need to
+				if(AssetBundleManager.ConnectionChecker != null && AssetBundleManager.ConnectionChecker.UseBundleIndexCaching == true)
+					if (AssetBundleManager.AssetBundleIndexObject != null)
+					{
+						Debug.Log("Caching downloaded index with Build version " + AssetBundleManager.AssetBundleIndexObject.bundlesPlayerVersion);
+						var cachedIndexPath = Path.Combine(Application.persistentDataPath, "cachedBundleIndex");
+						if (!Directory.Exists(cachedIndexPath))
+							Directory.CreateDirectory(cachedIndexPath);
+						cachedIndexPath = Path.Combine(cachedIndexPath, m_AssetBundleName + ".json");
+						File.WriteAllText(cachedIndexPath, JsonUtility.ToJson(AssetBundleManager.AssetBundleIndexObject));
+					}
                 return false;
             }
 			if (AssetBundleManager.AssetBundleIndexObject != null)
@@ -692,6 +748,48 @@ namespace UMA.AssetBundles
 				return false;
 			}
 			else
+			{
+				// if there has been an error make this return false
+				//It wont need any more updates and ABM needs to put it in failed downloads
+				if(string.IsNullOrEmpty(m_DownloadingError))
+					return true;
+				else
+				{
+					return false;
+				}
+			}
+		}
+	}
+
+	public class AssetBundleLoadCachedIndexOperation : AssetBundleLoadIndexOperation
+	{
+		public AssetBundleLoadCachedIndexOperation(string bundleName, string assetName, System.Type type, bool isJsonIndex = false)
+			: base(bundleName, assetName, type, isJsonIndex)
+		{
+			var cachedIndexPath = Path.Combine(Application.persistentDataPath, "cachedBundleIndex");
+			if (!Directory.Exists(cachedIndexPath))
+				Directory.CreateDirectory(cachedIndexPath);
+			cachedIndexPath = Path.Combine(cachedIndexPath, bundleName+".json");
+			if (File.Exists(cachedIndexPath))
+			{
+				Debug.Log("Cached index found for " + cachedIndexPath);
+				AssetBundleManager.AssetBundleIndexObject = ScriptableObject.CreateInstance<AssetBundleIndex>();
+				JsonUtility.FromJsonOverwrite(File.ReadAllText(cachedIndexPath), AssetBundleManager.AssetBundleIndexObject);
+				//AssetBundleManager.AssetBundleIndexObject = JsonUtility.FromJson<AssetBundleIndex>(File.ReadAllText(cachedIndexPath));
+			}
+			else
+			{
+				//we need an error saying no cached index existed
+				m_DownloadingError = "No cached Index existed for bundleName";
+            }
+		}
+
+		public override bool Update()
+		{
+			return false;
+		}
+		public override bool IsDone()
+		{
 				return true;
 		}
 	}

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleManager.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/AssetBundleManager.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 using UnityEditor;
 #endif
 using System;
+//we need System.IO now aswell to load cached bundleIndexes
+using System.IO;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -42,10 +44,10 @@ namespace UMA.AssetBundles
 		public string m_data;
 
 		internal event Action unload;
-
-		internal void OnUnload()
+		//Added a bool here to make it possible to unload loaded assets from the bundle too
+		internal void OnUnload(bool unloadAllLoadedObjects = false)
 		{
-			m_AssetBundle.Unload(false);
+			m_AssetBundle.Unload(unloadAllLoadedObjects);
 			if (unload != null)
 				unload();
 		}
@@ -90,6 +92,36 @@ namespace UMA.AssetBundles
 		static List<string> m_DownloadingBundles = new List<string>();
 		static List<AssetBundleLoadOperation> m_InProgressOperations = new List<AssetBundleLoadOperation>();
 		static Dictionary<string, string[]> m_Dependencies = new Dictionary<string, string[]>();
+
+		//a list of bundles that failed to download because we had no internet connection
+		//when we get a connection again we can restart them
+		static List<string> m_FailedBundleDownloads = new List<string>();
+
+		//made this static so re-initializing this does not cause multiples to be created
+		static GameObject generatedGO = null;
+
+		//the IConnectionChecker is an interface that can be used to tell us if there is an Internet connection and provides some methods we can trigger when things go wrong
+		static IConnectionChecker m_ConnectionChecker = null;
+
+		public static IConnectionChecker ConnectionChecker
+		{
+			get { return m_ConnectionChecker; }
+			set { m_ConnectionChecker = value; }
+		}
+
+		static bool m_UsingCachedIndex = false;
+		/// <summary>
+		/// Is the AssetBundleManager using a cached index (because its offline)?
+		/// </summary>
+		public static bool UsingCachedIndex { get { return m_UsingCachedIndex; } }
+
+		//these are used to store the values sent to the Initialize method when we started offline, 
+		//so that if/when we go online we can download and cache the live index
+		static string m_SessionIndexAssetBundleName = "";
+		static bool m_SessionUseJsonIndex;
+		static string m_SessionJsonIndexUrl = "";
+
+
 
 		public static bool SimulateOverride;
 
@@ -139,7 +171,10 @@ namespace UMA.AssetBundles
 		public static AssetBundleIndex AssetBundleIndexObject
 		{
 			get { return m_AssetBundleIndex; }
-			set { m_AssetBundleIndex = value; }
+			set {
+				m_UsingCachedIndex = false;
+				m_AssetBundleIndex = value;
+			}
 		}
 
 		private static void Log(LogType logType, string text)
@@ -241,6 +276,7 @@ namespace UMA.AssetBundles
 				if (!error.StartsWith("-"))
 				{
 					m_DownloadingErrors[assetBundleName] = "-" + error;
+					error = m_DownloadingErrors[assetBundleName];
 #if UNITY_EDITOR
 					if (assetBundleName == Utility.GetPlatformName().ToLower() + "index")
 					{
@@ -249,9 +285,11 @@ namespace UMA.AssetBundles
 							if (SimulateAssetBundleInEditor)
 							{
 								//we already outputted a message in DynamicAssetloader
+								SimulateOverride = true;
 							}
 							else
 							{
+								//I think here we dont have an internet connection and we need one to download this bundle
 								Debug.LogWarning("AssetBundleManager could not download the AssetBundleIndex from the Remote Server URL you have set in DynamicAssetLoader. Have you set the URL correctly and uploaded your AssetBundles?");
 								error = "AssetBundleManager could not download the AssetBundleIndex from the Remote Server URL you have set in DynamicAssetLoader. Have you set the URL correctly and uploaded your AssetBundles?";
 							}
@@ -263,8 +301,8 @@ namespace UMA.AssetBundles
 							Debug.LogWarning("Switched to Simulation mode because no AssetBundles were found. Have you build them? (Go to 'Assets/AssetBundles/Build AssetBundles').");
 							error = "Switched to Simulation mode because no AssetBundles were found.Have you build them? (Go to 'Assets/AssetBundles/Build AssetBundles').";
 							//this needs to hide the loading infobox- or something needs too..
-						}
 						SimulateOverride = true;
+					  }
 					}
 					else
 #endif
@@ -306,7 +344,6 @@ namespace UMA.AssetBundles
 			string error;
 			if (m_DownloadingErrors.TryGetValue(assetBundleName, out error))
 			{
-				Debug.LogWarning(error);
 				return 0;
 			}
 
@@ -421,9 +458,6 @@ namespace UMA.AssetBundles
 		/// Initializes asset bundle namager and starts download of index asset bundle
 		/// </summary>
 		/// <returns>Returns the index asset bundle download operation object.</returns>
-		// TODO I think that the index should be available if the device is offline. 
-		// Right now I think ABM always tries to download the index and the game will break if it cant.
-		// What I think should happen is that if the game is offline it should still be able to get a cached index
 		static public AssetBundleLoadIndexOperation Initialize()
 		{
 			return Initialize(Utility.GetPlatformName(), false, "");
@@ -449,20 +483,63 @@ namespace UMA.AssetBundles
 #if UNITY_EDITOR
 			Log(LogType.Info, "Simulation Mode: " + (SimulateAssetBundleInEditor ? "Enabled" : "Disabled"));
 #endif
-
-			var go = new GameObject("AssetBundleManager", typeof(AssetBundleManager));
-			DontDestroyOnLoad(go);
+			//Dont make another one if we are 're-initializing'
+			if (generatedGO == null)
+			{
+				generatedGO = new GameObject("AssetBundleManager", typeof(AssetBundleManager));
+				DontDestroyOnLoad(generatedGO);
+            }
+			else
+			{
+				//
+			}
 
 #if UNITY_EDITOR
 			// If we're in Editor simulation mode, we don't need the index assetBundle.
 			if (SimulateAssetBundleInEditor)
 				return null;
 #endif
+			//if we have a connectionChecker use it to check we have a connection- otherwise assume we do
+			bool connected = m_ConnectionChecker != null ? m_ConnectionChecker.InternetAvailable : true;
+			if (connected)
+			{
 			//as of 05/08/2016 we dont use Unitys AssetBundleManifest at all we just use our AssetBundleIndex
 			LoadAssetBundle(indexAssetBundleName.ToLower() + "index", true, useJsonIndex, jsonIndexUrl);
 			var operation = new AssetBundleLoadIndexOperation(indexAssetBundleName.ToLower() + "index", indexAssetBundleName + "Index", typeof(AssetBundleIndex), useJsonIndex);
 			m_InProgressOperations.Add(operation);
 			return operation;
+		}
+			else //if we dont have a connection try to load a cached index otherwise trigger m_ConnectionChecker.ShowConnectionRequiredUI()
+			{
+				m_SessionIndexAssetBundleName = indexAssetBundleName;
+				m_SessionUseJsonIndex = useJsonIndex;
+				m_SessionJsonIndexUrl = jsonIndexUrl;
+				//if we are not using index caching always trigger the ShowConnectionRequiredUI because we cant do anything without an index.
+				if (!m_ConnectionChecker.UseBundleIndexCaching)
+				{
+					Debug.LogWarning("[AssetBundleManager] Could not load the bundle index because there was no connection, and UseBundleIndexCaching was off");
+					m_ConnectionChecker.ShowConnectionRequiredUI();
+					return null;
+				}
+				else
+				{
+					//this operation will load the cached index if there is one
+					var operation = new AssetBundleLoadCachedIndexOperation(indexAssetBundleName.ToLower() + "index", indexAssetBundleName + "Index", typeof(AssetBundleIndex), useJsonIndex);
+					//so if(m_AssetBundleIndex == null) after that we need to call m_ConnectionChecker.ShowConnectionRequiredUI() because we cant do anything without an index
+					if (m_AssetBundleIndex == null)
+					{
+						Debug.LogWarning("[AssetBundleManager] Could not load the bundle index because there was no connection, and there was no cached index");
+						m_ConnectionChecker.ShowConnectionRequiredUI();
+					}
+					else
+					{
+						m_UsingCachedIndex = true;
+                        m_LoadedAssetBundles.Add(indexAssetBundleName.ToLower() + "index", new LoadedAssetBundle("CachedIndex"));
+					}
+					m_InProgressOperations.Add(operation);
+					return operation;
+				}
+			}
 		}
 
 		// Temporarily work around a il2cpp bug
@@ -505,6 +582,10 @@ namespace UMA.AssetBundles
 			// Load dependencies.
 			if (!isAlreadyProcessed && !isLoadingAssetBundleIndex)
 				LoadDependencies(assetBundleName);
+			else
+			{
+				Debug.LogWarning("Did not load deps for  " + assetBundleName + " was already processed " + isAlreadyProcessed);
+			}
 		}
 
 		/// <summary>
@@ -604,14 +685,13 @@ namespace UMA.AssetBundles
 		static protected bool LoadAssetBundleInternal(string assetBundleToFind, bool isLoadingAssetBundleIndex = false, bool useJsonIndex = false, string jsonIndexUrl = "")
 		{
 			//encrypted bundles have the suffix 'encrypted' appended to the name TODO this should probably go in the index though and be settable in the UMAAssetBundleManagerSettings window
-			//string encryptedSuffix = BundleEncryptionKey != "" ? "encrypted" : "";
 			string assetBundleToGet = assetBundleToFind;
-			if(BundleEncryptionKey != "" && m_AssetBundleIndex != null)
+			if(BundleEncryptionKey != "" && isLoadingAssetBundleIndex == false)
 			{
 				assetBundleToGet = m_AssetBundleIndex.GetAssetBundleEncryptedName(assetBundleToFind);
 				Debug.Log("assetBundleToFind was " + assetBundleToFind + " assetBundleToGet was " + assetBundleToGet);
             }
-			else if(BundleEncryptionKey != "" && m_AssetBundleIndex == null)
+			else if(BundleEncryptionKey != "" && isLoadingAssetBundleIndex == true)
 			{
 				assetBundleToGet = assetBundleToFind + "encrypted";
 			}
@@ -621,6 +701,7 @@ namespace UMA.AssetBundles
 			m_LoadedAssetBundles.TryGetValue(assetBundleToFind, out bundle);//encrypted or not this will have the assetbundlename without the 'encrypted' suffix
 			if (bundle != null && bundle.m_AssetBundle != null)
 			{
+				Debug.Log("[AssetBundleManager] " + assetBundleToFind + " was already loaded");
 				bundle.m_ReferencedCount++;
 				return true;
 			}
@@ -628,7 +709,10 @@ namespace UMA.AssetBundles
 			// @TODO: Do we need to consider the referenced count of WWWs?
 			// users can call LoadAssetAsync()/LoadLevelAsync() several times then wait them to be finished which might have duplicate WWWs.
 			if (m_DownloadingBundles.Contains(assetBundleToFind))
+			{
+				Debug.Log("[AssetBundleManager] " + assetBundleToFind + " was already downloading");
 				return true;
+			}
 
 			string bundleBaseDownloadingURL = GetAssetBundleBaseDownloadingURL(assetBundleToFind);
 
@@ -660,8 +744,6 @@ namespace UMA.AssetBundles
 
 				WWW download = null;
 				// For index assetbundle, always download it as we don't have hash for it.
-				//TODO make something to test if there is and internet connection and if not try to get a cached version of this so we can still access the stuff that has been previously cached
-				//TODO2 Make the index cache somewhere when it is downloaded.
 				if (isLoadingAssetBundleIndex)
 				{
 					if (useJsonIndex && jsonIndexUrl != "")
@@ -714,17 +796,26 @@ namespace UMA.AssetBundles
 				dependencies[i] = RemapVariantName(dependencies[i]);
 
 			// Record and load all dependencies.
+			//If a failed download is added again this dictionary will already have an entry for it so check for that
+			if (m_Dependencies.ContainsKey(assetBundleName))
+			{
+				m_Dependencies[assetBundleName] = dependencies;
+            }
+			else
+			{
 			m_Dependencies.Add(assetBundleName, dependencies);
+			}
 			for (int i = 0; i < dependencies.Length; i++)
 				LoadAssetBundleInternal(dependencies[i], false);
 		}
+		//This was not working with DynamicAssetloader is that still the case? 
 		/// <summary>
-		/// WARNING Not working right with DynamicAssetLoader yet! Unloads all AssetBundles compressed data (not the assets loaded from the bundle) to free up memory
+		/// Unloads all unused AssetBundles compressed data to free up memory.
 		/// </summary>
 		static public void UnloadAllAssetBundles()
 		{
 #if UNITY_EDITOR
-			// If we're in Editor simulation mode, we don't have to load the manifest assetBundle.
+			// If we're in Editor simulation mode, we wont have actually loaded and bundles
 			if (SimulateAssetBundleInEditor)
 				return;
 #endif
@@ -742,13 +833,13 @@ namespace UMA.AssetBundles
 
 		}
 		/// <summary>
-		/// Unloads assetbundle and its dependencies.
+		/// Unloads assetbundle and its dependencies
 		/// </summary>
 		/// <param name="assetBundleName"></param>
 		static public void UnloadAssetBundle(string assetBundleName)
 		{
 #if UNITY_EDITOR
-			// If we're in Editor simulation mode, we don't have to load the index assetBundle.
+			// If we're in Editor simulation mode, we have actually loaded any asset bundles
 			if (SimulateAssetBundleInEditor)
 				return;
 #endif
@@ -768,11 +859,12 @@ namespace UMA.AssetBundles
 			{
 				UnloadAssetBundleInternal(dependency);
 			}
-
+			//This may not actually get unloaded if its actually referenced so check that
+			if(!m_LoadedAssetBundles.ContainsKey(assetBundleName))
 			m_Dependencies.Remove(assetBundleName);
 		}
-
-		static protected void UnloadAssetBundleInternal(string assetBundleName, bool disregardRefrencedStatus = false)
+		//Added a bool here to make it possible to unload loaded assets from the bundle too
+        static protected void UnloadAssetBundleInternal(string assetBundleName, bool disregardRefrencedStatus = false, bool unloadAllLoadedObjects = false)
 		{
 			string error;
 			LoadedAssetBundle bundle = GetLoadedAssetBundle(assetBundleName, out error);
@@ -781,7 +873,7 @@ namespace UMA.AssetBundles
 
 			if (--bundle.m_ReferencedCount == 0 || disregardRefrencedStatus)
 			{
-				bundle.OnUnload();
+				bundle.OnUnload(unloadAllLoadedObjects);
 				m_LoadedAssetBundles.Remove(assetBundleName);
 
 				Log(LogType.Info, assetBundleName + " has been unloaded successfully");
@@ -804,7 +896,163 @@ namespace UMA.AssetBundles
 					ProcessFinishedOperation(operation);
 				}
 			}
+			
+			if(m_AssetBundleIndex == null)
+			{
+				RedownloadAssetBundleIndex();
+			}
+			//if we have a connection now and FailedDownloads has stuff in it (which only happens if downloads fail because there is no connection)
+			//we can start those downloads again
+			if (m_FailedBundleDownloads.Count > 0 && m_ConnectionChecker != null && m_ConnectionChecker.InternetAvailable && m_ConnectionChecker.RestartFailedDownloads)
+			{
+				RestartFailedDownloads();
+            }
 		}
+
+		/// <summary>
+		/// If a cached assetBundleIndex was used because the application was running off line, call this method when a connection is
+		/// established, to make AssetBundleManager download a live version. If the ConnectionChecker.UseBundleIndexCaching is true
+		/// the downloaded version will be cached.
+		/// </summary>
+		public static void RedownloadAssetBundleIndex()
+		{
+#if UNITY_EDITOR
+			// If we're in Editor simulation mode, we wont have actually loaded any bundles
+			if (SimulateAssetBundleInEditor)
+				return;
+#endif
+			//there is no point in doing this unless we have a connection
+			if (ConnectionChecker == null || ConnectionChecker.InternetAvailable)
+			{
+				bool alreadyLoading = false;
+				for (int i = 0; i < m_InProgressOperations.Count; i++)
+				{
+					if (m_InProgressOperations[i].GetType() == typeof(AssetBundleLoadIndexOperation))
+						alreadyLoading = true;
+				}
+				if (!alreadyLoading)
+				{
+					//we are also going to need to remove it from downloaded bundles otherwise it will get skipped
+					m_LoadedAssetBundles.Remove(m_SessionIndexAssetBundleName.ToLower() + "index");
+					//the operation does not update if the index is not null- can we get away with making it null?
+					m_AssetBundleIndex = null;
+					//
+					//do we do anything if we dont actually have an index right now? Or are we in fact calling Init anyway?
+					LoadAssetBundle(m_SessionIndexAssetBundleName.ToLower() + "index", true, m_SessionUseJsonIndex, m_SessionJsonIndexUrl);
+					var operation = new AssetBundleLoadIndexOperation(m_SessionIndexAssetBundleName.ToLower() + "index", m_SessionIndexAssetBundleName + "Index", typeof(AssetBundleIndex), m_SessionUseJsonIndex);
+					m_InProgressOperations.Add(operation);
+				}
+			}
+			else if (ConnectionChecker != null && !ConnectionChecker.InternetAvailable)
+			{
+				//If we dont have an index at all Update will have called this- in that case dont log
+				if (m_AssetBundleIndex != null)
+					Debug.LogWarning("[AssetbundleManager] RedownloadAssetBundleIndex aborted because there was no Internet Connection!");
+			}
+		}
+		/// <summary>
+		/// Restarts any downloads that failed because there was no cached version and no Internet Connection was available.
+		/// Requires that the AssetBundleManager has an IConnectionChecker object assigned to check the connection.
+		/// </summary>
+		public static void RestartFailedDownloads()
+		{
+			if (m_FailedBundleDownloads.Count > 0 && m_ConnectionChecker != null && m_ConnectionChecker.InternetAvailable)
+			{
+				if (m_AssetBundleIndex == null)
+				{
+					//Update will do this automatically now
+                }
+				else
+				{
+					for (int i = 0; i < m_FailedBundleDownloads.Count; i++)
+					{
+						var assetBundleName = m_FailedBundleDownloads[i];
+						//remove the bundle from download errors
+						//remove it from failedDownloads
+						//start it again
+						if (m_DownloadingErrors.ContainsKey(assetBundleName))
+							m_DownloadingErrors.Remove(assetBundleName);
+						m_FailedBundleDownloads.Remove(assetBundleName);
+						//we need to remove any dependencies from failedDownloads and errors too
+						string[] dependencies = null;
+						m_Dependencies.TryGetValue(assetBundleName, out dependencies);
+						if (dependencies != null && dependencies.Length > 0)
+						{
+							for (int di = 0; di < dependencies.Length; di++)
+							{
+								if (m_DownloadingErrors.ContainsKey(dependencies[di]))
+									m_DownloadingErrors.Remove(dependencies[di]);
+								if (m_FailedBundleDownloads.Contains(dependencies[di]))
+									m_FailedBundleDownloads.Remove(dependencies[di]);
+							}
+						}
+						Debug.LogWarning("RELOADING " + assetBundleName + " after connection established");
+						LoadAssetBundle(assetBundleName);//this will create a new operation which I dont want really
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// CAUTION Only call this method when the active scene is not using any assetBundle assets! Unloads all currently loaded assetBundles and any assets loaded
+		/// from them and redownloads them if the current index finds that the cached versions are not uptodate. 
+		/// Use this when the user has been offline and a cached index/assetbundles were used, and the user has now gone online. 
+		/// </summary>
+		public static void RedownloadActiveBundles()
+		{
+			//if there is no index we cant do anything
+			if (m_AssetBundleIndex == null)
+				return;
+			//there is no point in doing this unless we have a connection
+			if (ConnectionChecker == null || ConnectionChecker.InternetAvailable)
+			{
+				//if we are using a cached index do we need to update it? Or do we leave it to the dev to do that?
+				//
+				List<string> assetBundlesToReload = new List<string>();
+				foreach (KeyValuePair<string, LoadedAssetBundle> kp in m_LoadedAssetBundles)
+				{
+					if (kp.Key.IndexOf(Utility.GetPlatformName().ToLower() + "index") == -1)//dont try to unload the index...
+						assetBundlesToReload.Add(kp.Key);
+				}
+				//Unload them all
+				for (int i = 0; i < assetBundlesToReload.Count; i++)
+				{
+					if (m_Dependencies.ContainsKey(assetBundlesToReload[i]))
+						m_Dependencies.Remove(assetBundlesToReload[i]);
+					UnloadAssetBundleInternal(assetBundlesToReload[i], true, true);
+				}
+				for (int i = 0; i < assetBundlesToReload.Count; i++)
+				{
+					LoadAssetBundle(assetBundlesToReload[i]);
+				}
+			}
+			else if(ConnectionChecker != null && !ConnectionChecker.InternetAvailable)
+			{
+				Debug.LogWarning("[AssetbundleManager] RedownloadActiveBundles aborted because there was no Internet Connection!");
+			}
+		}
+
+		/// <summary>
+		/// Unloads all assetBundles and any loaded content. CAUTION This will probably break a running game! Should only be used when you want
+		/// to enable the user to clear their cache of downloaded data and to do that you need to 'unlock' any used asset bundles by unloading them first.
+		/// </summary>
+		//TODO Make this work- as soon as they get deleted they get loaded again...
+		/*public static void ForcefullyUnloadAllAssetBundles()
+		{
+			List<string> assetBundlesToUnload = new List<string>();
+			foreach (KeyValuePair<string, LoadedAssetBundle> kp in m_LoadedAssetBundles)
+			{
+				if (kp.Key.IndexOf(Utility.GetPlatformName().ToLower() + "index") == -1)//dont try to unload the index...
+					assetBundlesToUnload.Add(kp.Key);
+			}
+			//Unload them all
+			for (int i = 0; i < assetBundlesToUnload.Count; i++)
+			{
+				if (m_Dependencies.ContainsKey(assetBundlesToUnload[i]))
+					m_Dependencies.Remove(assetBundlesToUnload[i]);
+				UnloadAssetBundleInternal(assetBundlesToUnload[i], true, true);
+			}
+		}*/
 
 		void ProcessFinishedOperation(AssetBundleLoadOperation operation)
 		{
@@ -822,6 +1070,43 @@ namespace UMA.AssetBundles
 				string msg = string.Format("Failed downloading bundle {0} from {1}: {2}",
 						download.assetBundleName, download.GetSourceURL(), download.error);
 				m_DownloadingErrors.Add(download.assetBundleName, msg);
+				//if this failed and we have no internet connection we can probably assume thats the reason...
+				//in that case add it to the failedDownloads list so that if we do get an internet connection we can start it again.
+				if (m_ConnectionChecker != null /*&& !m_ConnectionChecker.InternetAvailable*/)
+				{
+					if (!m_ConnectionChecker.InternetAvailable)
+						//show the user that an internet connection was required to get this bundle
+						//Its up to the devloper how they use this interface method...
+						m_ConnectionChecker.ShowConnectionRequiredUI();
+					else
+					{
+						//This will happen when there is an internet connection, that is working (i.e. the connection check passes)
+						//but for some reason the download is still failing- like if there is a storm and very small amounts of data
+						//download fine but large amounts fail
+						Debug.LogError("SHOW DOWNLOAD FAILED UI");
+						m_ConnectionChecker.ShowDownloadFailedUI(download.assetBundleName);
+					}
+					//add it to failed downloads
+					if (!m_FailedBundleDownloads.Contains(download.assetBundleName))
+					{
+						//Debug.LogWarning(msg);//dont think we need to show the warning because it will get shown
+						//when progress for the bundle is requested- but then maybe ShowConnectionRequiredUI() should only happen when progress is requested
+						//but then the requesting code might not know which bundle was not cached and caused the error?
+						//So maybe we should show the warning LOL
+						m_FailedBundleDownloads.Add(download.assetBundleName);
+					}
+					//Dependencies will have failed too
+					string[] dependencies = null;
+					m_Dependencies.TryGetValue(download.assetBundleName, out dependencies);
+					if (dependencies != null && dependencies.Length > 0)
+					{
+						for (int i = 0; i < dependencies.Length; i++)
+						{
+							if (!m_FailedBundleDownloads.Contains(dependencies[i]))
+								m_FailedBundleDownloads.Add(dependencies[i]);
+						}
+					}
+				}
 			}
 			m_DownloadingBundles.Remove(download.assetBundleName);
 		}
@@ -886,6 +1171,48 @@ namespace UMA.AssetBundles
 
 			return operation;
 		}
-
+#if UNITY_EDITOR
+		//We can have an EditorHelper so we can see what is actually going on with this thing in the inspector...
+		public class EditorHelper
+		{
+			public List<string> loadedBundles = new List<string>();
+			public List<string> downloadingBundles = new List<string>();
+			public List<string> inProgressOperations = new List<string>();
+			public List<string> failedDownloads = new List<string>();
+			public bool isUsingCachedIndex;
+			public string bundleIndexPlayerversion = "0.0";
+			public EditorHelper()
+			{
+			}
+			public void Update()
+			{
+				loadedBundles.Clear();
+				foreach (KeyValuePair<string, LoadedAssetBundle> kp in m_LoadedAssetBundles)
+				{
+					loadedBundles.Add(kp.Key);
+				}
+				downloadingBundles.Clear();
+				downloadingBundles.AddRange(m_DownloadingBundles);//be nice if these showed progress
+				inProgressOperations.Clear();
+				for (int i = 0; i < m_InProgressOperations.Count; i++)
+				{
+					try
+					{
+						inProgressOperations.Add(
+							((AssetBundleDownloadOperation)m_InProgressOperations[i]).assetBundleName + " : " +
+							((AssetBundleDownloadOperation)m_InProgressOperations[i]).downloadProgress);
+					}
+					catch
+					{
+						inProgressOperations.Add("unknown operation");
+					}
+				}
+				failedDownloads.Clear();
+				failedDownloads.AddRange(m_FailedBundleDownloads);//maybe these could show the error
+				isUsingCachedIndex = m_UsingCachedIndex;
+				bundleIndexPlayerversion = m_AssetBundleIndex != null && !string.IsNullOrEmpty(m_AssetBundleIndex.bundlesPlayerVersion) ? m_AssetBundleIndex.bundlesPlayerVersion : "0.0";
+            }
+		}
+#endif
 	} // End of AssetBundleManager.
 }

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/BuildScript.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/BuildScript.cs
@@ -59,13 +59,44 @@ namespace UMA.AssetBundles
 
 				//AssetBundleIndex
 				AssetBundleIndex thisIndex = ScriptableObject.CreateInstance<AssetBundleIndex>();
+				//Added a bundlesPlayerVersion value to the assetBundles that can be used when determining
+				//whether the app version matches the bundles version or if the bundles/application require updating.
+				if (UMAABMSettings.EnableBundleIndexVersioning)
+				{
+					string versionErrMsg = "";
+					if (UMAABMSettings.BundleIndexVersioningMethod == UMAABMSettingsStore.BundleIndexVersioningOpts.UseBuildVersion)
+					{
+						thisIndex.bundlesPlayerVersion = Application.version;
+						versionErrMsg = "there was no 'Version' value set up in Edit->ProjectSettings->Player->Version";
+					}
+					else if (UMAABMSettings.BundleIndexVersioningMethod == UMAABMSettingsStore.BundleIndexVersioningOpts.Custom)
+					{
+						thisIndex.bundlesPlayerVersion = UMAABMSettings.BundleIndexCustomValue;
+						versionErrMsg = "there was no value set up UMA-> UMA AssetBundle Manager window";
+					}
+					if (string.IsNullOrEmpty(thisIndex.bundlesPlayerVersion))
+					{
+						EditorUtility.DisplayDialog("Bundle Index Versioning Error", "You have turned on 'Bundle Index Versioning' but " + versionErrMsg + ". Please set that and try building your bundles again.", "OK");
+						return;
+					}
+					else
+					{
+						if (!EditorUtility.DisplayDialog("Building Bundles", "Asset Bundles will be built with bundlesPlayerVersion value of '" + thisIndex.bundlesPlayerVersion + "' Is that correct?", "Build", "Cancel"))
+						{
+							//If the user did not aggree to that bail.
+							return;
+						}
+					}
+				}
 
 				string[] assetBundleNamesArray = AssetDatabase.GetAllAssetBundleNames();
-
 				//Generate a buildmap as we go
 				AssetBundleBuild[] buildMap = new AssetBundleBuild[assetBundleNamesArray.Length + 1];//+1 for the index bundle
 				for (int i = 0; i < assetBundleNamesArray.Length; i++)
 				{
+					//Building the map takes a while so show something...
+					EditorUtility.DisplayProgressBar("Building Asset Bundles", "Creating Build Map", (1f / (float)assetBundleNamesArray.Length) * (i + 1) );
+
 					string bundleName = assetBundleNamesArray[i];
 
 					string[] assetBundleAssetsArray = AssetDatabase.GetAssetPathsFromAssetBundle(bundleName);
@@ -97,6 +128,8 @@ namespace UMA.AssetBundles
 					}
 				}
 
+				EditorUtility.ClearProgressBar();
+
 				thisIndexAssetPath = "Assets/" + Utility.GetPlatformName() + "Index.asset";
 				thisIndex.name = "AssetBundleIndex";
 				AssetDatabase.CreateAsset(thisIndex, thisIndexAssetPath);
@@ -111,11 +144,11 @@ namespace UMA.AssetBundles
 				{
 					throw new System.Exception("Your assetBundles did not build properly.");
 				}
-				//reload the saved index (TODO may not be necessary)
 				thisIndex = AssetDatabase.LoadAssetAtPath<AssetBundleIndex>("Assets/" + Utility.GetPlatformName() + "Index.asset");
 				//Get any bundles with variants
 				string[] bundlesWithVariant = assetBundleManifest.GetAllAssetBundlesWithVariant();
 				thisIndex.bundlesWithVariant = bundlesWithVariant;
+
 				//then loop over each bundle in the bundle names and get the bundle specific data
 				for (int i = 0; i < assetBundleNamesArray.Length; i++)
 				{
@@ -165,7 +198,7 @@ namespace UMA.AssetBundles
 					var encryptedOutputPath = Path.Combine(Utility.AssetBundlesOutputPath, Path.Combine("Encrypted", Utility.GetPlatformName()));
 					if (!Directory.Exists(encryptedOutputPath))
 						Directory.CreateDirectory(encryptedOutputPath);
-					for (int bmi = 0; bmi < buildMap.Length; bmi++)//-1 to not include the index bundle (or maybe we do encrypt the index bundle?)
+					for (int bmi = 0; bmi < buildMap.Length; bmi++)
 					{
 						var thisEncryptionAsset = AssetDatabase.LoadAssetAtPath<UMAEncryptedBundle>(thisEncryptionAssetPath);
 						//get the data from the unencrypted bundle and encrypt it into the EncryptedData asset

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/Editor/AssetBundleManagerInspector.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/Editor/AssetBundleManagerInspector.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace UMA.AssetBundles
+{
+	[CustomEditor(typeof(AssetBundleManager),true)]
+	public class AssetBundleManagerInspector : Editor
+	{
+		protected AssetBundleManager thisABM;
+		protected AssetBundleManager.EditorHelper _editorhelper;
+		public void OnEnable()
+		{
+			thisABM = target as AssetBundleManager;
+		}
+
+		public void Update()
+		{
+			if (_editorhelper != null)
+			{
+                _editorhelper.Update();
+            }
+		}
+		public void OnDestroy()
+		{
+			EditorApplication.update -= Update;
+		}
+
+		public override void OnInspectorGUI()
+		{
+			EditorUtility.SetDirty(target);//this makes the editor helper update every frame
+			DrawDefaultInspector();
+			if (_editorhelper == null)
+			{
+				_editorhelper = new AssetBundleManager.EditorHelper();
+				_editorhelper.Update();
+				EditorApplication.update += Update;
+			}
+			DrawEditorHelper();
+		}
+
+		private void DrawEditorHelper()
+		{
+			EditorGUILayout.LabelField("In Progress Operations", EditorStyles.boldLabel);
+			for (int i = 0; i < _editorhelper.inProgressOperations.Count; i++)
+				EditorGUILayout.TextField("", _editorhelper.inProgressOperations[i]);
+			EditorGUILayout.Space();
+			EditorGUILayout.LabelField("Downloading Bundles", EditorStyles.boldLabel);
+			for (int i = 0; i < _editorhelper.downloadingBundles.Count; i++)
+				EditorGUILayout.TextField("", _editorhelper.downloadingBundles[i]);
+			EditorGUILayout.Space();
+			EditorGUILayout.LabelField("Loaded Bundles", EditorStyles.boldLabel);
+			for (int i = 0; i < _editorhelper.loadedBundles.Count; i++)
+				EditorGUILayout.TextField("", _editorhelper.loadedBundles[i]);
+			EditorGUILayout.Space();
+			EditorGUILayout.LabelField("Failed Downloads", EditorStyles.boldLabel);
+			for (int i = 0; i < _editorhelper.failedDownloads.Count; i++)
+				EditorGUILayout.TextField("", _editorhelper.failedDownloads[i]);
+			EditorGUILayout.Space();
+			EditorGUILayout.ToggleLeft("Is Using Cached Index", _editorhelper.isUsingCachedIndex);
+			EditorGUILayout.HelpBox("Bundles Index Player version: " + _editorhelper.bundleIndexPlayerversion, MessageType.None);
+		}
+	}
+}

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/Editor/AssetBundleManagerInspector.cs.meta
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/Editor/AssetBundleManagerInspector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4bfc84d4f349a4043ac50158e6c39c6f
+timeCreated: 1510493913
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/GUI/AssetBundleLoadingIndicator.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/GUI/AssetBundleLoadingIndicator.cs
@@ -104,18 +104,24 @@ namespace UMA.AssetBundles
 				if (_bundlesToCheck.Count > 0)
 				{
 					float overallProgress = 0;
-					//var newBundlesToCheck = new List<string>();
+					var newBundlesToCheck = new List<string>();
 					for (int i = 0; i < _bundlesToCheck.Count; i++)
 					{
 						var thisProgress = AssetBundleManager.GetBundleDownloadProgress(_bundlesToCheck[i], true);
-						/*if(thisProgress != 1f)
+						if(thisProgress != 1f)
 						{
 							newBundlesToCheck.Add(_bundlesToCheck[i]);
-						}*/
 						overallProgress += thisProgress;
 					}
+						
+					}
+					_bundlesToCheck = newBundlesToCheck;
+					if (_bundlesToCheck.Count > 0)
+					{
 					percentDone = overallProgress / _bundlesToCheck.Count;
-					//_bundlesToCheck = newBundlesToCheck;
+					}
+					else
+						percentDone = 1f;
 				}
 				UpdateProgress();
 			}

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/IConnectionChecker.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/IConnectionChecker.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UMA.AssetBundles
+{
+	//Use this Interface to enable AssetbundleManager to check if it has internet access and/or attempt allow your app to run offline. 
+	//If the bundle index and bundles themselves have previously been downloaded ABM will use the last cached version of the index to allow it to load cached bundles.
+	//Create a script that uses this interface as a wrapper for an Internet Connection checker such as 'OnlineCheckPro' or 'InternetReachbility'
+	//Your script should set itself as AssetbundleManager's static ConnectionChecker value when it starts.
+	public interface IConnectionChecker
+	{
+		//Should tell AssetBundleManager if there is a connection. You should make sure your connection checker completes its initial connection test before anything (ie DynamicAssetLoader) calls Initialize on the AssetBundleManager
+		//i.e make the connection checker turn the DynamicAssetLoader game object on after its completed its initial check (DAL initializes ABM in the UMA implimentation)
+		bool InternetAvailable { get; }
+
+		//Should tell AssetBundleManager to cache a successfully downloaded bundleIndex and also to load it if there is no connection. It is stored in Application.persistentDataPath + "/cachedBundleIndex/"+ platformIndexName +".json"
+		bool UseBundleIndexCaching { get; }
+
+		//Should tell AssetBundleManager whether to restart any downloads that failed because there was no connection automatically or not.
+		bool RestartFailedDownloads { get; }
+
+		//AssetBundleManager will call this if it requires a connection to complete an operation (i.e. if it has no cached index, or is trying to download a bundle that it cannot load from the cache using LoadFromCacheOrDownload)
+		//you could make this method show the user a message that they need to connect to the internet
+		void ShowConnectionRequiredUI();
+
+		//triggered by AssetbundleManager when a connection is available but a download fails because of a storm or something else stopping large downloads
+		//If RestartFailedDownloads is true ABM will keep trying to download, so you should keep a note of the failed downloads and when they complete 
+		//(or if the connection disappears and so ShowConnectionRequiredUI gets called) you should hide any UI you display
+		//You can set RestartFailedDownloads to false while you carry out some further checks.
+		void ShowDownloadFailedUI(string downloadThatFailed);
+    }
+}

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/IConnectionChecker.cs.meta
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/IConnectionChecker.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1f435e17b85262f40b9c738a4389dce0
+timeCreated: 1511828750
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
@@ -29,6 +29,13 @@ namespace UMA.AssetBundles
 #endif
 		bool newEncodeNamesSetting = false;
 
+		//DOS MODIFIED 14/11/2017 added a ability to set the new bundlesPlayerVersion value
+		bool _enableBundleIndexVersioning;
+		//either automatically use the Buildversion from player settings or specify a value here
+		UMAABMSettingsStore.BundleIndexVersioningOpts _bundleIndexVersioningMethod = UMAABMSettingsStore.BundleIndexVersioningOpts.UseBuildVersion;
+		//if useBundlesVersioning is set to Custom this value is used when the bundles are built
+		string _bundleIndexCustomValue = "0.0";
+
 		//server related
 		bool _enableLocalAssetBundleServer;
 		int _port;
@@ -113,6 +120,7 @@ namespace UMA.AssetBundles
 #if ENABLE_IOS_APP_SLICING
 			currentAppSlicingSetting = UMAABMSettings.GetBuildForSlicing();
 #endif
+			_enableBundleIndexVersioning = UMAABMSettings.EnableBundleIndexVersioning;
         }
 
 		void OnEnable()
@@ -126,6 +134,7 @@ namespace UMA.AssetBundles
 #if ENABLE_IOS_APP_SLICING
 			currentAppSlicingSetting = UMAABMSettings.GetBuildForSlicing();
 #endif
+			_enableBundleIndexVersioning = UMAABMSettings.EnableBundleIndexVersioning;
 			//localAssetBundleServer status
 			_enableLocalAssetBundleServer = EditorPrefs.GetBool(Application.dataPath+"LocalAssetBundleServerEnabled");
 			_port = EditorPrefs.GetInt(Application.dataPath + "LocalAssetBundleServerPort", 7888);
@@ -260,7 +269,47 @@ namespace UMA.AssetBundles
 			BeginVerticalPadded(5, new Color(0.75f, 0.875f, 1f));
 
 			GUILayout.Label("AssetBundle Options", EditorStyles.boldLabel);
-
+			//AssetBundle Build versioning
+			EditorGUI.BeginChangeCheck();
+			_enableBundleIndexVersioning = EditorGUILayout.ToggleLeft("Enable AssetBundle Index Versioning", _enableBundleIndexVersioning);
+			if (EditorGUI.EndChangeCheck())
+			{
+				UMAABMSettings.EnableBundleIndexVersioning = _enableBundleIndexVersioning;
+            }
+			if (_enableBundleIndexVersioning)
+			{
+				BeginVerticalIndented(10, new Color(0.75f, 0.875f, 1f));
+				EditorGUILayout.HelpBox("Sets the 'bundlesPlayerVersion' value of the AssetBundleIndex when you build your bundles. You can use this to determine if your app needs to force the user to go online to update their bundles and/or application (its up to you how you do that though!). ", MessageType.Info);
+				EditorGUI.BeginChangeCheck();
+				_bundleIndexVersioningMethod = (UMAABMSettingsStore.BundleIndexVersioningOpts)EditorGUILayout.EnumPopup("Bundles Versioning Method", _bundleIndexVersioningMethod);
+				if (EditorGUI.EndChangeCheck())
+				{
+					UMAABMSettings.BundleIndexVersioningMethod = _bundleIndexVersioningMethod;
+				}
+				if(_bundleIndexVersioningMethod == UMAABMSettingsStore.BundleIndexVersioningOpts.Custom)
+				{
+					EditorGUI.BeginChangeCheck();
+					_bundleIndexCustomValue = EditorGUILayout.TextField("Bundles Index Player Version", _bundleIndexCustomValue);
+					if (EditorGUI.EndChangeCheck())
+					{
+						UMAABMSettings.BundleIndexCustomValue = _bundleIndexCustomValue;
+                    }
+                }
+				else
+				{
+					var currentBuildVersion = Application.version;
+					if (string.IsNullOrEmpty(currentBuildVersion))
+					{
+						EditorGUILayout.HelpBox("Please be sure to set a 'Version' number (eg 1.0, 2.1.0) in Edit->ProjectSettings->Player->Version", MessageType.Warning);
+					}
+					else
+					{
+						EditorGUILayout.HelpBox("Current 'Version' number ("+currentBuildVersion+ ") will be used. You can change this in Edit->ProjectSettings->Player->Version.", MessageType.Info);
+					}
+				}
+				EditorGUILayout.Space();
+				EndVerticalIndented();
+			}
 			//Asset Bundle Encryption
 			//defined here so we can modify the message if encryption settings change
 			string buildBundlesMsg = "";
@@ -436,7 +485,7 @@ namespace UMA.AssetBundles
 #if UNITY_2017_2_OR_NEWER
 				Caching.ClearCache ();
 #else
-				Caching.CleanCache();          
+				Caching.ClearCache();          
 #endif
 				return;
 			}
@@ -547,7 +596,7 @@ namespace UMA.AssetBundles
 #if UNITY_2017_2_OR_NEWER
 					_statusMessage = Caching.ClearCache() ? "Cache Cleared." : "Error clearing cache.";
 #else
-					_statusMessage = Caching.CleanCache() ? "Cache Cleared." : "Error clearing cache.";
+					_statusMessage = Caching.ClearCache() ? "Cache Cleared." : "Error clearing cache.";
 #endif
 				}
 				EditorGUILayout.Space();
@@ -669,12 +718,20 @@ namespace UMA.AssetBundles
 	[System.Serializable]
 	public class UMAABMSettingsStore
 	{
+		public enum BundleIndexVersioningOpts { UseBuildVersion, Custom }
+
 		public bool encryptionEnabled = false;
 		public string encryptionPassword = "";
 		public string encryptionSuffix = "";
 		public bool encodeNames = false;
 		[Tooltip("If true will build uncompressed assetBundles for use with iOS resource catalogs")]
 		public bool buildForAppSlicing = false;
+
+		public bool enableBundleIndexVersioning;
+		//either automatically use the Buildversion from player settings or specify a value here
+		public BundleIndexVersioningOpts bundleIndexVersioningMethod = BundleIndexVersioningOpts.UseBuildVersion;
+		//if useBundlesVersioning is set to Custom this value is used when the bundles are built
+		public string bundleIndexCustomValue = "0.0";
 
 		public UMAABMSettingsStore() { }
 
@@ -691,11 +748,64 @@ namespace UMA.AssetBundles
 	{
 		#region PUBLIC FIELDS
 
-		public const string SETTINGS_FILENAME = "UMAEncryptionSettings-DoNotDelete.txt";
+		//This is not just for Encryption settings any more so it has the wrong name- its editor only so we can change it...
+		public const string SETTINGS_FILENAME = "UMAABMSettings-DoNotDelete.txt";
+		public const string SETTINGS_OLD_FILENAME = "UMAEncryptionSettings-DoNotDelete.txt";
+
+		private static UMAABMSettingsStore thisSettings;
+		#endregion
+
+		#region PROPERTIES
+		//pretty much all of these should have been properties- sorry I didn't uderstand those very well at the time
+
+		//This is better but we dont want to be doing GetThisSettings() either we want another property that does it once
+		/// <summary>
+		/// Is BundlesIndexVersioning enabled
+		/// </summary>
+		public static bool EnableBundleIndexVersioning
+		{
+			get { return GetThisSettings().enableBundleIndexVersioning; }
+			set{ GetThisSettings().enableBundleIndexVersioning = value;
+				File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), JsonUtility.ToJson(thisSettings));
+				AssetDatabase.Refresh();
+			}
+		}
+
+		/// <summary>
+		/// Does BundlesIndexversioning use a custom value or the Player build Value
+		/// </summary>
+		public static UMAABMSettingsStore.BundleIndexVersioningOpts BundleIndexVersioningMethod
+		{
+			get { return GetThisSettings().bundleIndexVersioningMethod; }
+			set { GetThisSettings().bundleIndexVersioningMethod = value;
+				File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), JsonUtility.ToJson(thisSettings));
+				AssetDatabase.Refresh();
+			}
+		}
+		/// <summary>
+		/// A custom value for bundleIndexVersioning
+		/// </summary>
+		public static string BundleIndexCustomValue
+		{
+			get { return GetThisSettings().bundleIndexCustomValue; }
+			set {
+				GetThisSettings().bundleIndexCustomValue = value;
+				File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), JsonUtility.ToJson(thisSettings));
+				AssetDatabase.Refresh();
+			}
+		}
+
 
 		#endregion
 
 		#region STATIC LOAD SAVE Methods
+		private static UMAABMSettingsStore GetThisSettings()
+		{
+			thisSettings = GetEncryptionSettings();
+			if (thisSettings == null)
+				thisSettings = new UMAABMSettingsStore();
+			return thisSettings;
+		}
 
 		private static string GetSettingsFolderPath()
 		{
@@ -705,11 +815,18 @@ namespace UMA.AssetBundles
 		//we are saving the encryptions settings to a text file so that teams working on the same project/ github etc/ can all use the same settings
 		public static UMAABMSettingsStore GetEncryptionSettings()
 		{
+			if(File.Exists(Path.Combine(GetSettingsFolderPath(), SETTINGS_OLD_FILENAME)))
+			{
+				//we need to write the data from the old file into the new file and delete the old one...
+				File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), File.ReadAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_OLD_FILENAME)));
+				File.Delete(Path.Combine(GetSettingsFolderPath(), SETTINGS_OLD_FILENAME));
+            }
 			if (!File.Exists(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME)))
 				return null;
 			else
 				return JsonUtility.FromJson<UMAABMSettingsStore>(File.ReadAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME)));
 		}
+
 		public static bool GetEncryptionEnabled()
 		{
 			var thisSettings = GetEncryptionSettings();
@@ -758,8 +875,13 @@ namespace UMA.AssetBundles
 
 		public static void ClearEncryptionSettings()
 		{
-			var thisSettings = new UMAABMSettingsStore();
-			File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), JsonUtility.ToJson(thisSettings));
+			var thisSettings = GetEncryptionSettings();
+			var newSettings = new UMAABMSettingsStore();
+			newSettings.buildForAppSlicing = thisSettings.buildForAppSlicing;
+			newSettings.bundleIndexCustomValue = thisSettings.bundleIndexCustomValue;
+			newSettings.bundleIndexVersioningMethod = thisSettings.bundleIndexVersioningMethod;
+			newSettings.enableBundleIndexVersioning = thisSettings.enableBundleIndexVersioning;
+			File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), JsonUtility.ToJson(newSettings));
 		}
 
 		public static void SetEncryptionSettings(bool encryptionEnabled, string encryptionPassword = "", string encryptionSuffix = "", bool? encodeNames = null)
@@ -772,12 +894,7 @@ namespace UMA.AssetBundles
 			thisSettings.encryptionSuffix = encryptionSuffix != "" ? encryptionSuffix : thisSettings.encryptionSuffix;
 			thisSettings.encodeNames = encodeNames != null ? (bool)encodeNames : thisSettings.encodeNames;
 			File.WriteAllText(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), JsonUtility.ToJson(thisSettings));
-			//need to make this show right in Unity when its inspected
-			/*TextAsset textAsset = (TextAsset)AssetDatabase.LoadAssetAtPath(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), typeof(TextAsset));
-			EditorUtility.SetDirty(textAsset);
-			AssetDatabase.SaveAssets();*/
 			AssetDatabase.Refresh();
-			//AssetDatabase.ImportAsset(Path.Combine(GetSettingsFolderPath(), SETTINGS_FILENAME), typeof(TextAsset));
 		}
 		/// <summary>
 		/// Turns encryption OFF

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
@@ -485,7 +485,7 @@ namespace UMA.AssetBundles
 #if UNITY_2017_2_OR_NEWER
 				Caching.ClearCache ();
 #else
-				Caching.ClearCache();          
+				Caching.CleanCache();          
 #endif
 				return;
 			}
@@ -596,7 +596,7 @@ namespace UMA.AssetBundles
 #if UNITY_2017_2_OR_NEWER
 					_statusMessage = Caching.ClearCache() ? "Cache Cleared." : "Error clearing cache.";
 #else
-					_statusMessage = Caching.ClearCache() ? "Cache Cleared." : "Error clearing cache.";
+					_statusMessage = Caching.CleanCache() ? "Cache Cleared." : "Error clearing cache.";
 #endif
 				}
 				EditorGUILayout.Space();

--- a/UMAProject/Assets/UMA/InternalDataStore/InEditor/UMAEncryptionSettings-DoNotDelete.txt
+++ b/UMAProject/Assets/UMA/InternalDataStore/InEditor/UMAEncryptionSettings-DoNotDelete.txt
@@ -1,1 +1,0 @@
-{"encryptionEnabled":false,"encryptionPassword":"BBf1/JYc0HCqpZMuyp0Ddw==","encryptionSuffix":"encrypted","encodeNames":true}


### PR DESCRIPTION
ABM can now optionally integrate with an Internet connection Checker (via an IConnectionChecker interface)
This makes it possible for the Bundles index to be cached and used when the application is off line.
If there is no cached index and ABM starts offline it will call a method the developer should impliment to show the user a connection is required.
Once a connection is re-established DynamicAssetLoader will try to 'ReInitialize' ABM and cache the index it downloads.
If any downloads fail (because of no connection) ABM will call a method the developer can impliment to show the user a connection is required.
If any downloads fail (even if there is a connection) ABM will trigger a download failed method the developer can use to tell the user they need a better connection (but it will keep trying to download in the background)
The developer can also make use of 'AssetBundle Index Versioning' which will add a version number to the bundle index (by default the current build version). The developer can use this to figure out if the build of the app is suitable for the build of the bundles (and if its not tell the user they need to go online to update the app and/or bundles)
ABM now has an Inspector for UnityEditor that shows the progress of downloads, any failed downloads, and whether its using a cached index.
The UMAEncryptionSettings asset will automatically be renamed to UMAABMSettings when this update is deployed.