### PR TITLE
Warns user when they set a recipe to use a race that is indexed

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/RecipeEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/RecipeEditor.cs
@@ -21,6 +21,10 @@ namespace UMA.Editors
 
 		EditorWindow inspectorWindow;
 
+		//for showing a warning if any of the compatible races are missing or not assigned to bundles or the index
+		protected Texture warningIcon;
+		protected GUIStyle warningStyle;
+
 		public virtual void OnSceneDrag(SceneView view)
 		{
 			if (Event.current.type == EventType.DragUpdated)
@@ -135,6 +139,13 @@ namespace UMA.Editors
 
         public override void OnInspectorGUI()
         {
+			if (warningIcon == null)
+			{
+				warningIcon = EditorGUIUtility.FindTexture("console.warnicon.sml");
+				warningStyle = new GUIStyle(EditorStyles.label);
+                warningStyle.fixedHeight = warningIcon.height + 4f;
+				warningStyle.contentOffset = new Vector2(0, -2f);
+			}
 			if (_recipe == null) return;
             PowerToolsGUI();
             base.OnInspectorGUI();
@@ -208,6 +219,34 @@ namespace UMA.Editors
                 GUILayout.EndHorizontal();
             }
         }
+
+		/// <summary>
+		/// Checks if the given RaceData is in the globalLibrary or an assetBundle
+		/// </summary>
+		/// <param name="_raceData"></param>
+		/// <returns></returns>
+		protected bool RaceInIndex(RaceData _raceData)
+		{
+			if (UMAContext.Instance != null)
+			{
+				if (UMAContext.Instance.HasRace(_raceData.raceName) != null)
+					return true;
+			}
+
+			AssetItem ai = UMAAssetIndexer.Instance.GetAssetItem<RaceData>(_raceData.raceName);
+			if (ai != null)
+			{
+				return true;
+			}
+
+			string path = AssetDatabase.GetAssetPath(_raceData);
+			if (UMAAssetIndexer.Instance.InAssetBundle(path))
+			{
+				return true;
+			}
+
+			return false;
+		}
 	}
 	/*public class ShowGatheringNotification : EditorWindow
 	{

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/pWardrobeRecipeEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/Editor/pWardrobeRecipeEditor.cs
@@ -10,6 +10,8 @@ namespace UMA.Editors
 {
 	public partial class RecipeEditor
 	{
+		private Dictionary<string,RaceData> _compatibleRaceDatas = new Dictionary<string,RaceData>();
+
 		// Drop area for compatible Races
 		private void CompatibleRacesDropArea(Rect dropArea, List<string> compatibleRaces)
 		{
@@ -117,16 +119,12 @@ namespace UMA.Editors
 						generatedWardrobeSlotOptions = new List<string>();
 						generatedWardrobeSlotOptionsLabels = new List<string>();
 					}
-					List<RaceData> thisRaceDatas = new List<RaceData>();
+					UpdateCompatibleRacesDict(compatibleRaces);
 					for (int i = 0; i < compatibleRaces.Count; i++)
 					{
-						thisRaceDatas.Add(GetCompatibleRaceData(compatibleRaces[i]));
-					}
-					for (int i = 0; i < thisRaceDatas.Count; i++)
-					{
-						if (thisRaceDatas[i] != null)
+						if(_compatibleRaceDatas.ContainsKey(compatibleRaces[i]))
 						{
-							List<string> thisWardrobeSlots = thisRaceDatas[i].wardrobeSlots;
+							List<string> thisWardrobeSlots = _compatibleRaceDatas[compatibleRaces[i]].wardrobeSlots;
 							for (int wi = 0; wi < thisWardrobeSlots.Count; wi++)
 							{
 								//WardrobeSlots display as 'Hair (FemaleOnly)' (for example) if the wardrobe slot is only available for one of the compatible races
@@ -148,24 +146,22 @@ namespace UMA.Editors
 						else
 						{
 							//Compatible Race is missing
-							thisRaceDatas.RemoveAt(i);
 							selectedIndex = -2;
 						}
 					}
 					for (int i = 0; i < generatedWardrobeSlotOptions.Count; i++)
 					{
 						List<string> onlyIn = new List<string>();
-						for (int ii = 0; ii < thisRaceDatas.Count; ii++)
+						foreach(KeyValuePair<string,RaceData> kp in _compatibleRaceDatas)
 						{
-							if (thisRaceDatas[ii].wardrobeSlots.Contains(generatedWardrobeSlotOptions[i]))
+							if(kp.Value.wardrobeSlots.Contains(generatedWardrobeSlotOptions[i]))
 							{
-								onlyIn.Add(thisRaceDatas[ii].raceName);
+								onlyIn.Add(kp.Key);
 							}
 						}
-						if (onlyIn.Count < thisRaceDatas.Count)
+						if(onlyIn.Count < _compatibleRaceDatas.Count)
 						{
 							//its not in all of them
-							//generatedWardrobeSlotOptions[i] = generatedWardrobeSlotOptions[i] + "  (" + String.Join(", ", onlyIn.ToArray()) + " Only)";
 							generatedWardrobeSlotOptionsLabels[i] = generatedWardrobeSlotOptionsLabels[i] + "  (" + String.Join(", ", onlyIn.ToArray()) + " Only)";
 						}
 					}
@@ -195,11 +191,11 @@ namespace UMA.Editors
 				}
 				List<UMARecipeBase> thisBaseRecipes = new List<UMARecipeBase>();
 				Dictionary<string, List<string>> slotsRacesDict = new Dictionary<string, List<string>>();
+				UpdateCompatibleRacesDict(compatibleRaces);
 				for (int i = 0; i < compatibleRaces.Count; i++)
 				{
-					if (GetCompatibleRaceData(compatibleRaces[i]) == null)
-						continue;
-					thisBaseRecipes.Add(GetCompatibleRaceData(compatibleRaces[i]).baseRaceRecipe);
+					if(_compatibleRaceDatas.ContainsKey(compatibleRaces[i]))
+						thisBaseRecipes.Add(_compatibleRaceDatas[compatibleRaces[i]].baseRaceRecipe);
 				}
 				for (int i = 0; i < thisBaseRecipes.Count; i++)
 				{
@@ -236,7 +232,29 @@ namespace UMA.Editors
 				}
 			}
 		}
-
+		//Updates a dictionary of racenames and racedatas so that GetCompatibleRaceData is called far less frequently (because its slow)
+		private void UpdateCompatibleRacesDict(List<string> compatibleRaces)
+		{
+			if (compatibleRaces.Count == 0)
+			{
+				_compatibleRaceDatas.Clear();
+				return;
+			}
+			Dictionary<string, RaceData> newDict = new Dictionary<string, RaceData>();
+			for (int i = 0; i < compatibleRaces.Count; i++)
+			{
+				if (_compatibleRaceDatas.ContainsKey(compatibleRaces[i]))
+					newDict.Add(compatibleRaces[i], _compatibleRaceDatas[compatibleRaces[i]]);
+				else
+				{
+					var thisRaceData = GetCompatibleRaceData(compatibleRaces[i]);
+					if(thisRaceData != null)
+						newDict.Add(compatibleRaces[i], thisRaceData);
+				}
+			}
+			_compatibleRaceDatas = newDict;
+		}
+		//Avoid calling this all the time because its slow
 		private RaceData GetCompatibleRaceData(string raceName)
 		{
 			RaceData foundRace = null;
@@ -252,6 +270,7 @@ namespace UMA.Editors
 			}
 			return foundRace;
 		}
+
 		protected virtual bool DrawCompatibleRacesUI(Type TargetType, bool ShowHelp = false)
 		{
 			bool doUpdate = false;
@@ -269,6 +288,8 @@ namespace UMA.Editors
 			List<string> newCompatibleRaces = new List<string>(compatibleRaces);
 			List<WardrobeRecipeThumb> newWardrobeThumbs = new List<WardrobeRecipeThumb>();
 			List<string> wardrobeThumbsDropDown = new List<string>();
+
+			UpdateCompatibleRacesDict(compatibleRaces);
 
 			if (compatibleRaces.Count > 0)
 			{
@@ -294,7 +315,7 @@ namespace UMA.Editors
 				}
 			}
 
-			GUILayout.Space(10);
+			//GUILayout.Space(10);
 			Rect dropArea = new Rect();
 			Rect dropAreaBox = new Rect();
 			if (compatibleRaces.Count > 0)
@@ -316,12 +337,47 @@ namespace UMA.Editors
 				for (int i = 0; i < compatibleRaces.Count; i++)
 				{
 					GUILayout.Space(padding);
-					GUI.enabled = false; //we readonly to prevent typos
 					Rect crfRect = GUILayoutUtility.GetRect(0.0f, EditorGUIUtility.singleLineHeight, GUILayout.ExpandWidth(true));
 					Rect crfDelRect = crfRect;
 					crfRect.width = crfRect.width - 75f - 20f - 20f;
 					crfDelRect.width = 20f + padding;
-					crfDelRect.x = crfRect.width + 20f + padding;
+					crfDelRect.x = crfRect.width /*+ 20f*/ + padding;
+					//We need to check if the RaceData is in the index or an assetBundle otherwise show the add buttons
+					if(!_compatibleRaceDatas.ContainsKey(compatibleRaces[i]) || !RaceInIndex(_compatibleRaceDatas[compatibleRaces[i]]))
+					{
+						crfRect.width = crfRect.width - 20f;
+						crfRect.x = crfRect.x + 20f;
+						var warningRect = new Rect((crfRect.xMin - 20f), crfRect.yMin, 20f, crfRect.height);
+						string warningMsg = "";
+						//the race is in the project but not assigned to the index or any assetBundles
+						if (_compatibleRaceDatas.ContainsKey(compatibleRaces[i]))
+							warningMsg = compatibleRaces[i] + " is not indexed! Either assign it to an assetBundle or use one of the buttons below to add it to the Scene/Global Library.";
+						else //the race is missing from the project
+							warningMsg = compatibleRaces[i] + " could not be found in the project. Have you deleted it?";
+						var warningGUIContent = new GUIContent("", warningMsg);
+						warningGUIContent.image = warningIcon;
+						EditorGUI.LabelField(warningRect, warningGUIContent);
+						if (_compatibleRaceDatas.ContainsKey(compatibleRaces[i]))
+						{
+							Rect addButsRect = GUILayoutUtility.GetRect(0.0f, EditorGUIUtility.singleLineHeight, GUILayout.ExpandWidth(true));
+							addButsRect.xMin = crfRect.xMin;
+							addButsRect.width = crfRect.width;
+							Rect butScene = addButsRect;
+							Rect butIndex = addButsRect;
+							butScene.width = addButsRect.width / 3f;
+							butIndex.xMin = butScene.xMax;
+							butIndex.width = (addButsRect.width / 3f)*2;
+                            if (GUI.Button(butScene,"Add to Scene Only", EditorStyles.miniButton))
+							{
+								UMAContext.Instance.AddRace(_compatibleRaceDatas[compatibleRaces[i]]);
+							}
+							if (GUI.Button(butIndex,"Add to Global Index (Recommended)", EditorStyles.miniButton))
+							{
+								UMAAssetIndexer.Instance.EvilAddAsset(typeof(RaceData), _compatibleRaceDatas[compatibleRaces[i]]);
+							}
+						}
+					}
+					GUI.enabled = false; //we readonly to prevent typos
 					EditorGUI.TextField(crfRect, compatibleRaces[i]);
 					GUI.enabled = true;
 					if (GUI.Button(crfDelRect, "X"))
@@ -330,7 +386,7 @@ namespace UMA.Editors
 					}
 				}
 				Rect thumbnailRect = dropArea;
-				thumbnailRect.x = dropArea.width + padding + 20f;
+				thumbnailRect.x = dropArea.width + padding /*+ 20f*/;
 				thumbnailRect.width = 75f;
 				thumbnailRect.y = thumbnailRect.y - 3f;
 				Rect thumbnailDDRect = thumbnailRect;
@@ -396,7 +452,8 @@ namespace UMA.Editors
             {
                 EditorGUILayout.HelpBox("Compatible races are used to assign this recipe to a race or races. Recipes are restricted to the races to which they are assigned - you cannot assign wardrobe items to races that are not compatible. Thumbnails can be used to attach sprites to the recipe for use in UI design.", MessageType.Info);
             }
-            return doUpdate;
+			GUILayout.Space(10);
+			return doUpdate;
 		}
 
 		protected virtual bool DrawWardrobeSlotsFields(Type TargetType, bool ShowHelp = false)

--- a/UMAProject/Assets/UMA/Core/Scripts/RaceLibrary.cs
+++ b/UMAProject/Assets/UMA/Core/Scripts/RaceLibrary.cs
@@ -57,7 +57,41 @@ namespace UMA
 			raceElementList = list;
 			raceDictionary.Add(race.raceName, race);
 		}
-	#pragma warning restore 618
+#pragma warning restore 618
+
+		public override RaceData HasRace(string raceName)
+		{
+			if ((raceName == null) || (raceName.Length == 0))
+				return null;
+
+			ValidateDictionary();
+			RaceData res;
+			if (!raceDictionary.TryGetValue(raceName, out res))
+			{
+				return null;
+			}
+			return res;
+		}
+
+		public override RaceData HasRace(int raceHash)
+		{
+			if (raceHash == 0)
+				return null;
+
+			ValidateDictionary();
+
+			foreach (string name in raceDictionary.Keys)
+			{
+				int hash = UMAUtils.StringToHash(name);
+
+				if (hash == raceHash)
+				{
+					return raceDictionary[name];
+				}
+			}
+
+			return null;
+		}
 
 		override public RaceData GetRace(string raceName)
 		{

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/RaceLibraryBase.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/RaceLibraryBase.cs
@@ -8,10 +8,22 @@ namespace UMA
     public abstract class RaceLibraryBase : MonoBehaviour
     {
 		/// <summary>
+		/// Gets a race by name without trying to find it in the globalIndex or assetBundles
+		/// </summary>
+		/// <returns>The race (or null if not in library instance).</returns>
+		/// <param name="raceName">Name.</param>
+		public abstract RaceData HasRace(string raceName);
+		/// <summary>
+		/// Gets a race by name hash without trying to find it in the globalIndex or assetBundles
+		/// </summary>
+		/// <returns>The race (or null if not in library instance).</returns>
+		/// <param name="raceHash">Name hash.</param>
+		public abstract RaceData HasRace(int raceHash);
+		/// <summary>
 		/// Add a race to the library.
 		/// </summary>
 		/// <param name="race">Race.</param>
-        public abstract void AddRace(RaceData race);
+		public abstract void AddRace(RaceData race);
 		/// <summary>
 		/// Gets a race by name.
 		/// </summary>

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAContext.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAContext.cs
@@ -54,7 +54,26 @@ namespace UMA
 		}
 
 		/// <summary>
-		/// Gets a race by name.
+		/// Gets a race by name, if it has been added to the library
+		/// </summary>
+		/// <returns>The race.</returns>
+		/// <param name="name">Name.</param>
+		public RaceData HasRace(string name)
+		{
+			return raceLibrary.HasRace(name);
+		}
+		/// <summary>
+		/// Gets a race by name hash, if it has been added to the library.
+		/// </summary>
+		/// <returns>The race.</returns>
+		/// <param name="nameHash">Name hash.</param>
+		public RaceData HasRace(int nameHash)
+		{
+			return raceLibrary.HasRace(nameHash);
+		}
+
+		/// <summary>
+		/// Gets a race by name, if the library is a DynamicRaceLibrary it will try to find it.
 		/// </summary>
 		/// <returns>The race.</returns>
 		/// <param name="name">Name.</param>
@@ -63,7 +82,7 @@ namespace UMA
 			return raceLibrary.GetRace(name);
 		}
 		/// <summary>
-		/// Gets a race by name hash.
+		/// Gets a race by name hash, if the library is a DynamicRaceLibrary it will try to find it.
 		/// </summary>
 		/// <returns>The race.</returns>
 		/// <param name="nameHash">Name hash.</param>


### PR DESCRIPTION
Warns user when they set a recipe to use a race that is not in the global or scene library or any assetBundles.
Optimizes some wardrobeRecipeEditors methods for finding RaceDatas by racename.
Adds 'HasRace' to UMAContext/RaceLibrary/RaceLibraryBase to be more in line with slots/overlays (this method is not overridden by DynamicRaceLibrary and wont try to find a race it does not have)