### PR TITLE
Bugfix for Issue#93

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/DNARangeAsset.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/DNARangeAsset.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
+using System.Text.RegularExpressions;
 
 namespace UMA
 {
@@ -19,7 +20,7 @@ namespace UMA
 		/// <summary>
 		/// The DNA converter for which the ranges apply.
 		/// </summary>
-		public DnaConverterBehaviour dnaConverter;
+		public DynamicDNAConverterBehaviourBase dnaConverter;
 
 		/// <summary>
 		/// The mean (average) value for each DNA entry.
@@ -39,6 +40,28 @@ namespace UMA
 		public float[] spreads;
 
 		private float[] values;
+
+		public bool ContainsDNARange(int index, string name)
+		{
+			if (dnaConverter == null)
+				return false;
+			
+			if (dnaConverter.dnaAsset.Names.Length > index)
+			{
+				if (Regex.Replace(dnaConverter.dnaAsset.Names[index], "( )+", "") == Regex.Replace(name, "( )+", ""))
+					return true;
+			}
+			return false;
+		}
+
+		public bool ValueInRange(int index, float value)
+		{
+			float rangeMin = means[index] - spreads[index];
+			float rangeMax = means[index] + spreads[index];
+			if (value < rangeMin || value > rangeMax)
+				return false;
+			return true;
+		}
 
 		/// <summary>
 		/// Uniformly randomizes each value in the DNA.

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/DNARangeAsset.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/DNARangeAsset.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using System.Collections;
-using System.Text.RegularExpressions;
 
 namespace UMA
 {
@@ -20,7 +19,7 @@ namespace UMA
 		/// <summary>
 		/// The DNA converter for which the ranges apply.
 		/// </summary>
-		public DynamicDNAConverterBehaviourBase dnaConverter;
+		public DnaConverterBehaviour dnaConverter;
 
 		/// <summary>
 		/// The mean (average) value for each DNA entry.
@@ -40,28 +39,6 @@ namespace UMA
 		public float[] spreads;
 
 		private float[] values;
-
-		public bool ContainsDNARange(int index, string name)
-		{
-			if (dnaConverter == null)
-				return false;
-			
-			if (dnaConverter.dnaAsset.Names.Length > index)
-			{
-				if (Regex.Replace(dnaConverter.dnaAsset.Names[index], "( )+", "") == Regex.Replace(name, "( )+", ""))
-					return true;
-			}
-			return false;
-		}
-
-		public bool ValueInRange(int index, float value)
-		{
-			float rangeMin = means[index] - spreads[index];
-			float rangeMax = means[index] + spreads[index];
-			if (value < rangeMin || value > rangeMax)
-				return false;
-			return true;
-		}
 
 		/// <summary>
 		/// Uniformly randomizes each value in the DNA.

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/DNARangeInspector.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/DNARangeInspector.cs
@@ -15,16 +15,22 @@ namespace UMA.Editors
 
 		private DNARangeAsset dnaRange;
 		private UMADnaBase dnaSource;
+
 		private int entryCount = 0;
 		
 		public void OnEnable()
 		{
 			dnaRange = target as DNARangeAsset;
-			if (dnaRange.dnaConverter != null)
-			{
-				dnaSource = dnaRange.dnaConverter.DNAType.GetConstructor(System.Type.EmptyTypes).Invoke(null) as UMADnaBase;
+			if (dnaRange.dnaConverter != null) {
+				dnaSource = dnaRange.dnaConverter.DNAType.GetConstructor (System.Type.EmptyTypes).Invoke (null) as UMADnaBase;
 				if (dnaSource != null)
-					entryCount = dnaSource.Count;
+				{
+					if (dnaRange.dnaConverter.DNAType == typeof(DynamicUMADna)) {
+						entryCount = dnaRange.dnaConverter.dnaAsset.Names.Length;
+					} else {
+						entryCount = dnaSource.Count;
+					}
+				}
 			}
 		}
 
@@ -32,7 +38,8 @@ namespace UMA.Editors
 	    {
 			bool dirty = false;
 
-			DnaConverterBehaviour newSource = EditorGUILayout.ObjectField("DNA Converter", dnaRange.dnaConverter, typeof(DnaConverterBehaviour), true) as DnaConverterBehaviour;
+			DynamicDNAConverterBehaviourBase newSource = EditorGUILayout.ObjectField("DNA Converter", dnaRange.dnaConverter, typeof(DynamicDNAConverterBehaviourBase), true) as DynamicDNAConverterBehaviourBase;
+
 			if (newSource != dnaRange.dnaConverter)
 			{
 				dnaRange.dnaConverter = newSource;
@@ -41,15 +48,21 @@ namespace UMA.Editors
 				{
 					dnaSource = dnaRange.dnaConverter.DNAType.GetConstructor(System.Type.EmptyTypes).Invoke(null) as UMADnaBase;
 				}
-
 				if (dnaSource == null)
 				{
 					entryCount = 0;
 				}
 				else
 				{
-					entryCount = dnaSource.Count;
-				}
+					if (dnaRange.dnaConverter.DNAType == typeof(DynamicUMADna))
+					{
+						entryCount = dnaRange.dnaConverter.dnaAsset.Names.Length;
+					}
+					else
+					{
+						entryCount = dnaSource.Count;
+					}
+				}		
 				dnaRange.means = new float[entryCount];
 				dnaRange.deviations = new float[entryCount];
 				dnaRange.spreads = new float[entryCount];
@@ -74,7 +87,15 @@ namespace UMA.Editors
 				headerStyle.fontSize =  12;
 				EditorGUILayout.LabelField(dnaRange.dnaConverter.DNAType.Name, headerStyle); 
 
-				string[] dnaNames = dnaSource.Names;
+				string[] dnaNames;
+				if (dnaRange.dnaConverter.DNAType == typeof(DynamicUMADna))
+				{
+					dnaNames = dnaRange.dnaConverter.dnaAsset.Names;
+				}
+				else
+				{
+					dnaNames = dnaSource.Names;
+				}
 
 				for (int i = 0; i < entryCount; i++)
 				{

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/DNARangeInspector.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/DNARangeInspector.cs
@@ -15,22 +15,16 @@ namespace UMA.Editors
 
 		private DNARangeAsset dnaRange;
 		private UMADnaBase dnaSource;
-
 		private int entryCount = 0;
 		
 		public void OnEnable()
 		{
 			dnaRange = target as DNARangeAsset;
-			if (dnaRange.dnaConverter != null) {
-				dnaSource = dnaRange.dnaConverter.DNAType.GetConstructor (System.Type.EmptyTypes).Invoke (null) as UMADnaBase;
+			if (dnaRange.dnaConverter != null)
+			{
+				dnaSource = dnaRange.dnaConverter.DNAType.GetConstructor(System.Type.EmptyTypes).Invoke(null) as UMADnaBase;
 				if (dnaSource != null)
-				{
-					if (dnaRange.dnaConverter.DNAType == typeof(DynamicUMADna)) {
-						entryCount = dnaRange.dnaConverter.dnaAsset.Names.Length;
-					} else {
-						entryCount = dnaSource.Count;
-					}
-				}
+					entryCount = dnaSource.Count;
 			}
 		}
 
@@ -38,8 +32,7 @@ namespace UMA.Editors
 	    {
 			bool dirty = false;
 
-			DynamicDNAConverterBehaviourBase newSource = EditorGUILayout.ObjectField("DNA Converter", dnaRange.dnaConverter, typeof(DynamicDNAConverterBehaviourBase), true) as DynamicDNAConverterBehaviourBase;
-
+			DnaConverterBehaviour newSource = EditorGUILayout.ObjectField("DNA Converter", dnaRange.dnaConverter, typeof(DnaConverterBehaviour), true) as DnaConverterBehaviour;
 			if (newSource != dnaRange.dnaConverter)
 			{
 				dnaRange.dnaConverter = newSource;
@@ -48,21 +41,15 @@ namespace UMA.Editors
 				{
 					dnaSource = dnaRange.dnaConverter.DNAType.GetConstructor(System.Type.EmptyTypes).Invoke(null) as UMADnaBase;
 				}
+
 				if (dnaSource == null)
 				{
 					entryCount = 0;
 				}
 				else
 				{
-					if (dnaRange.dnaConverter.DNAType == typeof(DynamicUMADna))
-					{
-						entryCount = dnaRange.dnaConverter.dnaAsset.Names.Length;
-					}
-					else
-					{
-						entryCount = dnaSource.Count;
-					}
-				}		
+					entryCount = dnaSource.Count;
+				}
 				dnaRange.means = new float[entryCount];
 				dnaRange.deviations = new float[entryCount];
 				dnaRange.spreads = new float[entryCount];
@@ -87,15 +74,7 @@ namespace UMA.Editors
 				headerStyle.fontSize =  12;
 				EditorGUILayout.LabelField(dnaRange.dnaConverter.DNAType.Name, headerStyle); 
 
-				string[] dnaNames;
-				if (dnaRange.dnaConverter.DNAType == typeof(DynamicUMADna))
-				{
-					dnaNames = dnaRange.dnaConverter.dnaAsset.Names;
-				}
-				else
-				{
-					dnaNames = dnaSource.Names;
-				}
+				string[] dnaNames = dnaSource.Names;
 
 				for (int i = 0; i < entryCount; i++)
 				{

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Scripts/DNAEditor.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Scripts/DNAEditor.cs
@@ -10,6 +10,7 @@ namespace UMA.CharacterSystem
         UMADnaBase _Owner;   // different DNA 
         DynamicCharacterAvatar _Avatar;
         float _InitialValue;
+		DNARangeAsset _dnr;
 
         public Slider ValueSlider;
         public Text Label;
@@ -27,18 +28,37 @@ namespace UMA.CharacterSystem
             _Index = index;
             _Owner = owner;
             _Avatar = avatar;
-
-            //not used?
-            //DNARangeAsset[] dnr = avatar.RaceData.dnaRanges;
-            //dnr[0].
-            //             values[i] = means[i] + (Random.value - 0.5f) * spreads[i];
             _InitialValue = currentval;
+
+			DNARangeAsset[] dnaRangeAssets = avatar.activeRace.data.dnaRanges;
+			foreach (DNARangeAsset d in dnaRangeAssets) 
+			{
+				if (d.ContainsDNARange (_Index, _DNAName)) {
+					_dnr = d;
+					return;
+				}
+			}
         }
 
         public void ChangeValue(float value)
         {
-            _Owner.SetValue(_Index, value);
-            _Avatar.ForceUpdate(true, false, false);
+			if (_dnr == null) //No specified DNA Range Asset for this DNA
+			{ 
+				_Owner.SetValue (_Index, value);
+				_Avatar.ForceUpdate (true, false, false);				
+				return;
+			}
+			
+			if (_dnr.ValueInRange (_Index, value))
+			{
+				_Owner.SetValue (_Index, value);
+				_Avatar.ForceUpdate(true, false, false);
+				return;
+			}
+			else
+			{
+				//Debug.LogWarning ("DNA Value out of range!");
+			}
         }
     }
 }

--- a/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Scripts/DNAEditor.cs
+++ b/UMAProject/Assets/UMA/Examples/Extensions Examples/DynamicCharacterSystem/Scripts/DNAEditor.cs
@@ -10,7 +10,6 @@ namespace UMA.CharacterSystem
         UMADnaBase _Owner;   // different DNA 
         DynamicCharacterAvatar _Avatar;
         float _InitialValue;
-		DNARangeAsset _dnr;
 
         public Slider ValueSlider;
         public Text Label;
@@ -28,37 +27,18 @@ namespace UMA.CharacterSystem
             _Index = index;
             _Owner = owner;
             _Avatar = avatar;
-            _InitialValue = currentval;
 
-			DNARangeAsset[] dnaRangeAssets = avatar.activeRace.data.dnaRanges;
-			foreach (DNARangeAsset d in dnaRangeAssets) 
-			{
-				if (d.ContainsDNARange (_Index, _DNAName)) {
-					_dnr = d;
-					return;
-				}
-			}
+            //not used?
+            //DNARangeAsset[] dnr = avatar.RaceData.dnaRanges;
+            //dnr[0].
+            //             values[i] = means[i] + (Random.value - 0.5f) * spreads[i];
+            _InitialValue = currentval;
         }
 
         public void ChangeValue(float value)
         {
-			if (_dnr == null) //No specified DNA Range Asset for this DNA
-			{ 
-				_Owner.SetValue (_Index, value);
-				_Avatar.ForceUpdate (true, false, false);				
-				return;
-			}
-			
-			if (_dnr.ValueInRange (_Index, value))
-			{
-				_Owner.SetValue (_Index, value);
-				_Avatar.ForceUpdate(true, false, false);
-				return;
-			}
-			else
-			{
-				//Debug.LogWarning ("DNA Value out of range!");
-			}
+            _Owner.SetValue(_Index, value);
+            _Avatar.ForceUpdate(true, false, false);
         }
     }
 }


### PR DESCRIPTION
Resurrected DNA Range Assets--can be tested in the DNAConverterBehaviourCustomizer scene. Most useful for blendshapes currently as there are no blendshape modifiers on the morph DNA Converter yet.