### PR TITLE
single mesh blendshape & slot inspector

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/SlotDataAssetInspector.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/SlotDataAssetInspector.cs
@@ -7,6 +7,13 @@ namespace UMA.Editors
 	[CustomEditor(typeof(SlotDataAsset))]
     public class SlotDataAssetInspector : Editor
     {
+		SerializedProperty slotName;
+		SerializedProperty CharacterBegun;
+		SerializedProperty SlotAtlassed;
+		SerializedProperty DNAApplied;
+		SerializedProperty CharacterCompleted;
+
+		private bool eventsFoldout = false;
 
         [MenuItem("Assets/Create/UMA/Core/Custom Slot Asset")]
         public static void CreateCustomSlotAssetMenuItem()
@@ -14,42 +21,30 @@ namespace UMA.Editors
         	CustomAssetUtility.CreateAsset<SlotDataAsset>("", true, "Custom");
         }
 
-		//allow for delayed saving so typing in a field does not trigger save with every keystroke
-		private float lastActionTime = 0;
-		private bool doSave = false;
-
 		void OnEnable()
 		{
-			EditorApplication.update += DoDelayedSave;
+			slotName = serializedObject.FindProperty("slotName");
+			CharacterBegun = serializedObject.FindProperty("CharacterBegun");
+			SlotAtlassed = serializedObject.FindProperty("SlotAtlassed");
+			DNAApplied = serializedObject.FindProperty("DNAApplied");
+			CharacterCompleted = serializedObject.FindProperty("CharacterCompleted");
 		}
 
-		void OnDestroy()
-		{
-			EditorApplication.update -= DoDelayedSave;
-		}
-
-		void DoDelayedSave()
-		{
-			if (doSave && Time.realtimeSinceStartup > (lastActionTime + 0.5f))
-			{
-				doSave = false;
-				Debug.Log("Saved SlotDataAsset lastActionTime = " + lastActionTime + " realTime = " + Time.realtimeSinceStartup);
-				lastActionTime = Time.realtimeSinceStartup;
-				EditorUtility.SetDirty(target);
-				AssetDatabase.SaveAssets();
-			}
-		}
 		public override void OnInspectorGUI()
         {
-			if (lastActionTime == 0)
-				lastActionTime = Time.realtimeSinceStartup;
+			serializedObject.Update();
+			//base.OnInspectorGUI();
 
-			EditorGUI.BeginChangeCheck();
-			base.OnInspectorGUI();
-			if (EditorGUI.EndChangeCheck())
+			EditorGUILayout.DelayedTextField(slotName);
+			Editor.DrawPropertiesExcluding(serializedObject, new string[] { "slotName", "CharacterBegun", "SlotAtlassed", "DNAApplied", "CharacterCompleted" });
+
+			eventsFoldout = EditorGUILayout.Foldout(eventsFoldout, "Slot Events");
+			if (eventsFoldout)
 			{
-				lastActionTime = Time.realtimeSinceStartup;
-				doSave = true;
+				EditorGUILayout.PropertyField(CharacterBegun);
+				EditorGUILayout.PropertyField(SlotAtlassed);
+				EditorGUILayout.PropertyField(DNAApplied);
+				EditorGUILayout.PropertyField(CharacterCompleted);
 			}
 
 			foreach (var t in targets)
@@ -82,6 +77,9 @@ namespace UMA.Editors
 			GUI.Box(boneDropArea, "Drag Bone Transforms here to add their names to the Animated Bone Names.\nSo the power tools will preserve them!");
 			GUILayout.Space(10);
 			AnimatedBoneDropAreaGUI(boneDropArea);
+
+			serializedObject.ApplyModifiedProperties();
+			AssetDatabase.SaveAssets();
         }
 
         private void AnimatedBoneDropAreaGUI(Rect dropArea)

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMAMeshDataPropertyDrawer.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMAMeshDataPropertyDrawer.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace UMA.Editors
+{
+	[CustomPropertyDrawer(typeof(UMAMeshData))]
+	public class UMAMeshDataPropertyDrawer : PropertyDrawer
+	{
+		private bool foldout = false;
+
+		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+		{
+			return 0;//Let's override this to zero and use GUILayout. //foldout ? (lineHeight * num) : lineHeight;
+		}
+
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			//EditorGUI.BeginProperty(position, label, property);
+
+			foldout = EditorGUILayout.Foldout(foldout, "MeshData");
+			if (foldout)
+			{
+				EditorGUI.indentLevel++;
+				SerializedProperty vertexCount = PropertyCheck(property, "vertexCount");
+				SerializedProperty normals = PropertyCheck(property, "normals");
+				SerializedProperty tangents = PropertyCheck(property, "tangents");
+				SerializedProperty colors32 = PropertyCheck(property, "colors32");
+				SerializedProperty uv = PropertyCheck(property, "uv");
+				SerializedProperty uv2 = PropertyCheck(property, "uv2");
+				SerializedProperty uv3 = PropertyCheck(property, "uv3");
+				SerializedProperty uv4 = PropertyCheck(property, "uv4");
+				SerializedProperty clothSkinning = PropertyCheck(property, "clothSkinningSerialized");
+				SerializedProperty subMeshCount = PropertyCheck(property, "subMeshCount");
+				SerializedProperty umaBoneCount = PropertyCheck(property, "umaBoneCount");
+				SerializedProperty rootBoneName = PropertyCheck(property, "RootBoneName");
+				SerializedProperty blendshapes = PropertyCheck(property, "blendShapes");
+
+				EditorGUILayout.LabelField( "Vertex Count", vertexCount.intValue.ToString());
+				EditorGUILayout.LabelField("Normals Count", normals.arraySize.ToString());
+				EditorGUILayout.LabelField("Tangents Count", tangents.arraySize.ToString());
+				EditorGUILayout.LabelField("Colors32 Count", colors32.arraySize.ToString());
+				EditorGUILayout.LabelField("UV Count", uv.arraySize.ToString());
+				EditorGUILayout.LabelField("UV2 Count", uv2.arraySize.ToString());
+				EditorGUILayout.LabelField("UV3 Count", uv3.arraySize.ToString());
+				EditorGUILayout.LabelField("UV4 Count", uv4.arraySize.ToString());
+				EditorGUILayout.LabelField("ClothSkinning Count", clothSkinning.arraySize.ToString());
+				EditorGUILayout.LabelField("Submesh Count", subMeshCount.intValue.ToString());
+				EditorGUILayout.LabelField("UMABone Count", umaBoneCount.intValue.ToString());
+				EditorGUILayout.LabelField("RootBoneName", rootBoneName.stringValue);
+				EditorGUILayout.LabelField("BlendShape Count", blendshapes.arraySize.ToString());
+				EditorGUILayout.PropertyField( blendshapes, true );
+
+				EditorGUI.indentLevel--;
+			}
+
+			//EditorGUI.EndProperty();
+		}
+
+		private SerializedProperty PropertyCheck(SerializedProperty property, string relativeName)
+		{
+			SerializedProperty prop = property.FindPropertyRelative(relativeName);
+			if (prop == null)
+				Debug.LogError(string.Format("{0} property not found!", relativeName));
+			return prop;
+		}
+	}
+}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMAMeshDataPropertyDrawer.cs.meta
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/UMAMeshDataPropertyDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ddba82fb50a03e346927be3013a786c9
+timeCreated: 1513457018
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/SkinnedMeshCombiner.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/SkinnedMeshCombiner.cs
@@ -451,6 +451,7 @@ namespace UMA
 			target.uv4 = source.uv4;
 			target.vertexCount = source.vertexCount;
 			target.vertices = source.vertices;
+			target.blendShapes = source.blendShapes;
 
 			if (source.clothSkinningSerialized != null && source.clothSkinningSerialized.Length != 0)
 			{


### PR DESCRIPTION
Main thing to verify is if the slot inspector and umaMeshData propertyDrawer still works as expected.
I removed the delayed save in the slot inspector because using serializedObject.applyModifiedProperties appears to save only the changes instead of dirtying the entire object and re-saving.