### PR TITLE
Feature overlay inspector improvement

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/OverlayDataAssetInspector.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/Editor/OverlayDataAssetInspector.cs
@@ -12,8 +12,30 @@ namespace UMA.Editors
 		private float lastActionTime = 0;
 		private bool doSave = false;
 
+		private SerializedProperty _overlayName;
+		private SerializedProperty _overlayType;
+		private SerializedProperty _umaMaterial;
+		private SerializedProperty _textureList;
+		private SerializedProperty _channels;
+		private SerializedProperty _rect;
+		private SerializedProperty _alphaMask;
+		private SerializedProperty _tags;
+		private SerializedProperty _occlusionEntries;
+
+		private bool additionalFoldout = false;
+
+
 		void OnEnable()
 		{
+			_overlayName = serializedObject.FindProperty("overlayName");
+			_overlayType = serializedObject.FindProperty("overlayType");
+			_umaMaterial = serializedObject.FindProperty("material");
+			_textureList = serializedObject.FindProperty("textureList");
+			_rect = serializedObject.FindProperty("rect");
+			_alphaMask = serializedObject.FindProperty("alphaMask");
+			_tags = serializedObject.FindProperty("tags");
+			_occlusionEntries = serializedObject.FindProperty("OcclusionEntries");
+
 			EditorApplication.update += DoDelayedSave;
 		}
 
@@ -39,8 +61,69 @@ namespace UMA.Editors
 			if (lastActionTime == 0)
 				lastActionTime = Time.realtimeSinceStartup;
 
+			serializedObject.Update();
+
 			EditorGUI.BeginChangeCheck();
-			base.OnInspectorGUI();
+
+			EditorGUILayout.PropertyField(_overlayName);
+			EditorGUILayout.PropertyField(_overlayType);
+			EditorGUILayout.PropertyField(_rect);
+
+			EditorGUILayout.PropertyField(_umaMaterial);
+
+			if (_umaMaterial != null && _umaMaterial.objectReferenceValue != null)
+			{
+				int textureChannelCount = 0;
+				SerializedObject tempObj = new SerializedObject(_umaMaterial.objectReferenceValue);
+				_channels = tempObj.FindProperty("channels");
+
+				if (_channels == null)
+					EditorGUILayout.HelpBox("Channels not found!", MessageType.Error);
+				else
+					textureChannelCount = _channels.arraySize;
+
+				if (_textureList.arraySize <= 0 || _textureList.arraySize != textureChannelCount)
+					_textureList.arraySize = textureChannelCount;
+
+				EditorGUILayout.PropertyField(_textureList);
+
+				if (_textureList.isExpanded)
+				{
+					EditorGUI.indentLevel++;
+					for (int i = 0; i < _textureList.arraySize; i++)
+					{
+						SerializedProperty channel = _channels.GetArrayElementAtIndex(i);
+						string materialName = channel.FindPropertyRelative("materialPropertyName").stringValue;
+						EditorGUILayout.PropertyField(_textureList.GetArrayElementAtIndex(i), new GUIContent(materialName));
+					}
+					EditorGUI.indentLevel--;
+				}
+
+				bool allValid = true;
+				for (int i = 0; i < _textureList.arraySize; i++)
+				{
+					if (_textureList.GetArrayElementAtIndex(i).objectReferenceValue == null)
+						allValid = false;
+				}
+				if (!allValid)
+					EditorGUILayout.HelpBox("Not all textures in Texture List set!", MessageType.Error);
+			}
+			else
+				EditorGUILayout.HelpBox("No UMA Material selected!", MessageType.Warning);
+
+			GUILayout.Space(20f);
+			additionalFoldout = EditorGUILayout.Foldout(additionalFoldout, "Additional Parameters");
+
+			if (additionalFoldout)
+			{
+				EditorGUI.indentLevel++;
+				EditorGUILayout.PropertyField(_alphaMask);
+				EditorGUILayout.PropertyField(_tags, true);
+				EditorGUILayout.PropertyField(_occlusionEntries, true);
+				EditorGUI.indentLevel--;
+			}
+
+			serializedObject.ApplyModifiedProperties();
 			if (EditorGUI.EndChangeCheck())
 			{
 				lastActionTime = Time.realtimeSinceStartup;

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/OverlayDataAsset.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/OverlayDataAsset.cs
@@ -10,7 +10,8 @@ namespace UMA
 	[System.Serializable]
 	public partial class OverlayDataAsset : ScriptableObject, ISerializationCallbackReceiver
 	{
-	    public string overlayName;
+		[Tooltip("The name of this overlay.")]
+		public string overlayName;
 		[System.NonSerialized]
 		public int nameHash;
 
@@ -22,25 +23,30 @@ namespace UMA
 		/// <summary>
 		/// How should this overlay be processed.
 		/// </summary>
+		[Tooltip("Normal or Cutout overlay type. This determines whether or not to use a cutout shader during the texture merging process.")]
 		public OverlayType overlayType;
 		/// <summary>
 		/// Destination rectangle for drawing overlay textures.
 		/// </summary>
+		[Tooltip("Destination rectangle for drawing overlay textures.")]
 		public Rect rect;
 		/// <summary>
 		/// Optional Alpha mask, if alpha mask is not set the texture[0].alpha is used instead.
 		/// Using a alpha mask also allows you to write alpha values from the texture[0] to cut holes
 		/// </summary>
+		[Tooltip("Optional Alpha mask, if alpha mask is not set the texture[0].alpha is used instead.")]
 		public Texture alphaMask;
 		/// <summary>
 		/// Array of textures required for the overlay material.
 		/// </summary>
-	    public Texture[] textureList;
-        /// <summary>
-        /// Use this to identify what kind of overlay this is and what it fits
-        /// Eg. BaseMeshSkin, BaseMeshOverlays, GenericPlateArmor01
-        /// </summary>
-        public string[] tags;
+		[Tooltip("Array of textures required for the overlay material.")]
+		public Texture[] textureList;
+		/// <summary>
+		/// Use this to identify what kind of overlay this is and what it fits
+		/// Eg. BaseMeshSkin, BaseMeshOverlays, GenericPlateArmor01
+		/// </summary>
+		[Tooltip("Use this to identify what kind of overlay this is and what it fits.")]
+		public string[] tags;
 
 		/// <summary>
 		/// The UMA material.
@@ -50,6 +56,7 @@ namespace UMA
 		/// used for drawing and information needed for matching the textures
 		/// and colors to the various material properties.
 		/// </remarks>
+		[Tooltip("The UMA material contains both a reference to the Unity material used for drawing and information needed for matching the textures and colors to the various material properties.")]
 		[UMAAssetFieldVisible]
 		public UMAMaterial material;
 
@@ -131,12 +138,13 @@ namespace UMA
 		/// Occlusion Entries for occluding triangles, currently only supported by powertools.
 		/// It is important that the OcclusionEntries be sorted by slotNameHash ascending to allow fast binary lookup
 		/// </summary>
+		[Tooltip("Occlusion Entries for occluding triangles, currently only supported by powertools.")]
 		public OcclusionEntry[] OcclusionEntries;
 
 		public OverlayDataAsset()
-	    {
+		{
 
-	    }
+		}
 
 		public void OnAfterDeserialize()
 		{

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/SeamRemoval.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/SeamRemoval.cs
@@ -39,35 +39,38 @@ namespace UMA
 	        runScript = false;
 	    }
 
-	    public static Mesh PerformSeamRemoval(SkinnedMeshRenderer originalMesh, SkinnedMeshRenderer referenceMesh, float threshold)
-	    {
+		public static Mesh PerformSeamRemoval(SkinnedMeshRenderer originalMesh, SkinnedMeshRenderer referenceMesh, float threshold)
+		{
 			float sqrthreshold = threshold * threshold;
+			int matchCount = 0;
 			
-	        Vector3[] referenceVertices = referenceMesh.sharedMesh.vertices;
-	        Vector3[] referencenormals = referenceMesh.sharedMesh.normals;
+			Vector3[] referenceVertices = referenceMesh.sharedMesh.vertices;
+			Vector3[] referencenormals = referenceMesh.sharedMesh.normals;
 
-	        Vector3[] normals = originalMesh.sharedMesh.normals;
-	        Vector3[] meshIndexVertices = originalMesh.sharedMesh.vertices;
+			Vector3[] normals = originalMesh.sharedMesh.normals;
+			Vector3[] meshIndexVertices = originalMesh.sharedMesh.vertices;
 
-	        for (int vertexIndex = 0; vertexIndex < meshIndexVertices.Length; vertexIndex++)
-	        {
-	            for (int othervertexIndex = 0; othervertexIndex < referenceVertices.Length; othervertexIndex++)
-	            {
-	                if ((meshIndexVertices[vertexIndex] - referenceVertices[othervertexIndex]).sqrMagnitude <= sqrthreshold)
-	                {
+			for (int vertexIndex = 0; vertexIndex < meshIndexVertices.Length; vertexIndex++)
+			{
+				for (int othervertexIndex = 0; othervertexIndex < referenceVertices.Length; othervertexIndex++)
+				{
+					if ((meshIndexVertices[vertexIndex] - referenceVertices[othervertexIndex]).sqrMagnitude <= sqrthreshold)
+					{
+						matchCount++;
 						normals[vertexIndex] = referencenormals[othervertexIndex];
-	                }
-	            }
-	        }	
+					}
+				}
+			}
 
+			Debug.Log(string.Format("{0} matched vertices found during seam removal.", matchCount));
 			Mesh tempMesh = Instantiate(originalMesh.sharedMesh);
 			tempMesh.name = originalMesh.gameObject.name;
 			tempMesh.normals = normals;
 			
 			calculateMeshTangents(tempMesh);
 			
-	        return tempMesh;
-	    }
+			return tempMesh;
+		}
 		
 
 		public static void calculateMeshTangents(Mesh mesh)


### PR DESCRIPTION
I made a design decision.  When creating a new overlay and setting the uma material is when the texture list size on the overlay will be set.  It will do it automatically based on the number of channels in the uma material and there is no texture list size input.  I figured because the texture count and material channels have to match then might as well force it here.
Do you guys think otherwise?