### PR TITLE
Fix potential infinite loop

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorCoroutine.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorCoroutine.cs
@@ -371,7 +371,7 @@ namespace UMA
 				Vector2 tempResolution = new Vector2(umaGenerator.atlasResolution, umaGenerator.atlasResolution);
 
 				bool done = false;
-				while (!done)
+				while (!done && Mathf.Abs(usedArea.x) > 0.0001)
 				{
 					if (tempResolution.x * 0.5f >= usedArea.x)
 					{
@@ -384,7 +384,7 @@ namespace UMA
 				}
 
 				done = false;
-				while (!done)
+				while (!done && Mathf.Abs(usedArea.y) > 0.0001)
 				{
 
 					if (tempResolution.y * 0.5f >= usedArea.y)


### PR DESCRIPTION
On a headless linux build we ran into an issue where the server would just lock up for no reason
After a lot of fiddling about to figure out how to debug it (attach gbd + http://www.mono-project.com/docs/debug+profile/debug/#debugging-with-gdb ), we noticed it got stuck in UMAGeneratorCoroutine.OptimizeAtlas

It seems that the usedArea can end up being 0 on either axis in some cases, which will cause it to loop for a long time (endlessly?)

This is a quick and dirty fix to bypass the issue, I wasn't exactly sure how to handle this case properly so i just left GeneratedMaterial.cropResolution at the default value.
Can this be set to 0 or some other small value? Does it matter? (Havent had the time to dig through the code myself)

Not super sure on the 0 (Mathf.Abs(...) > 0.0001 ) check either, it should be fine?

I'd be more than happy to amend the patch if you could give me some pointers - or feel free to close & implement a better fix yourself