### PR TITLE
Change render queues on shaders/materials to help with skybox

### DIFF
--- a/UMAProject/Assets/UMA/Content/UMA_Contrib/Materials/UMA_Mesh_Hair_DoubleSided.mat
+++ b/UMAProject/Assets/UMA/Content/UMA_Contrib/Materials/UMA_Mesh_Hair_DoubleSided.mat
@@ -10,7 +10,7 @@ Material:
   m_Shader: {fileID: 4800000, guid: d56eff61c40904d78becb18c718ce22e, type: 3}
   m_ShaderKeywords: _ALPHATEST_ON _NORMALMAP
   m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 3000
   stringTagMap: {}
   m_SavedProperties:
     serializedVersion: 2

--- a/UMAProject/Assets/UMA/Content/UMA_Contrib/Materials/UMA_Mesh_Hair_SingleSided.mat
+++ b/UMAProject/Assets/UMA/Content/UMA_Contrib/Materials/UMA_Mesh_Hair_SingleSided.mat
@@ -10,7 +10,7 @@ Material:
   m_Shader: {fileID: 4800000, guid: 0b87e405f94845c4b81d32f132cda54b, type: 3}
   m_ShaderKeywords: _ALPHATEST_ON _NORMALMAP
   m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
+  m_CustomRenderQueue: 3000
   stringTagMap: {}
   m_SavedProperties:
     serializedVersion: 2

--- a/UMAProject/Assets/UMA/Content/UMA_Core/HumanShared/Materials/Shaders/HairFadeCutout.shader
+++ b/UMAProject/Assets/UMA/Content/UMA_Core/HumanShared/Materials/Shaders/HairFadeCutout.shader
@@ -25,7 +25,7 @@ Shader "UMA/Hair Fade Cutout"
 
 	SubShader
 	{
-		Tags{ "RenderType" = "TransparentCutout"  "Queue" = "AlphaTest+0" }
+		Tags{ "RenderType" = "TransparentCutout"  "Queue" = "Transparent" }
 		Cull Back
 		CGINCLUDE
 		#include "UnityStandardUtils.cginc"
@@ -70,7 +70,7 @@ Shader "UMA/Hair Fade Cutout"
 
 		ENDCG
 		
-		Tags{ "RenderType" = "Transparent"  "Queue" = "Transparent+0" "IgnoreProjector" = "True" }
+		Tags{ "RenderType" = "Transparent"  "Queue" = "Transparent+10" "IgnoreProjector" = "True" }
 		Cull Off
 		CGINCLUDE
 		#include "UnityStandardUtils.cginc"

--- a/UMAProject/Assets/UMA/Content/UMA_Core/HumanShared/Materials/Shaders/HairFadeCutout2.shader
+++ b/UMAProject/Assets/UMA/Content/UMA_Core/HumanShared/Materials/Shaders/HairFadeCutout2.shader
@@ -23,7 +23,7 @@ Shader "UMA/Hair Fade2 Cutout"
 
 	SubShader
 	{
-		Tags{ "RenderType" = "TransparentCutout"  "Queue" = "AlphaTest+0" }
+		Tags{ "RenderType" = "TransparentCutout"  "Queue" = "Transparent" }
 		Cull Back
 		CGINCLUDE
 		#include "UnityStandardUtils.cginc"
@@ -69,7 +69,7 @@ Shader "UMA/Hair Fade2 Cutout"
 
 		ENDCG
 		
-		Tags{ "RenderType" = "Transparent"  "Queue" = "Transparent+0" "IgnoreProjector" = "True" }
+		Tags{ "RenderType" = "Transparent"  "Queue" = "Transparent+10" "IgnoreProjector" = "True" }
 		Cull Back
 		CGINCLUDE
 		#include "UnityStandardUtils.cginc"

--- a/UMAProject/Assets/UMA/Content/UMA_Core/HumanShared/Materials/Shaders/HairFadeCutoutSS.shader
+++ b/UMAProject/Assets/UMA/Content/UMA_Core/HumanShared/Materials/Shaders/HairFadeCutoutSS.shader
@@ -23,7 +23,7 @@ Shader "UMA/Hair Fade Cutout (Single Sided)"
 
 	SubShader
 	{
-		Tags{ "RenderType" = "TransparentCutout"  "Queue" = "AlphaTest+0" }
+		Tags{ "RenderType" = "TransparentCutout"  "Queue" = "Transparent" }
 		Cull Back
 		CGINCLUDE
 		#include "UnityStandardUtils.cginc"
@@ -69,7 +69,7 @@ Shader "UMA/Hair Fade Cutout (Single Sided)"
 
 		ENDCG
 		
-		Tags{ "RenderType" = "Transparent"  "Queue" = "Transparent+0" "IgnoreProjector" = "True" }
+		Tags{ "RenderType" = "Transparent"  "Queue" = "Transparent+10" "IgnoreProjector" = "True" }
 		Cull Back
 		CGINCLUDE
 		#include "UnityStandardUtils.cginc"

--- a/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMASimpleLOD.cs
+++ b/UMAProject/Assets/UMA/Examples/Main Examples/Scripts/UMASimpleLOD.cs
@@ -15,8 +15,10 @@ namespace UMA.Examples
 		public int lodOffset;
 		[Tooltip("This is the max LOD to search for if the current LOD can't be found.")]
 		public int maxLOD = 5;
+      [Tooltip("The maximum scale reduction (8 means the texture can be reduced in half 8 times)")]
+      public int maxReduction = 8;
 
-		public int CurrentLOD {  get { return _currentLOD - lodOffset; } }
+      public int CurrentLOD {  get { return _currentLOD - lodOffset; } }
 		private int _currentLOD = -1;
 
 		private DynamicCharacterAvatar _avatar;
@@ -41,7 +43,7 @@ namespace UMA.Examples
 		public void Awake()
 		{
 			_currentLOD = -1;
-		}
+      }
 
 		public void OnEnable()
 		{
@@ -96,7 +98,9 @@ namespace UMA.Examples
 			float atlasResolutionScale = 1f;
 
 			int currentLevel = 0;
-			while (lodDistance != 0 && cameraDistance > lodDistanceStep)
+         float maxReductionf = 1.0f / maxReduction;
+
+         while (lodDistance != 0 && cameraDistance > lodDistanceStep)
 			{
 				lodDistanceStep *= 2;
 				atlasResolutionScale *= 0.5f;
@@ -104,7 +108,12 @@ namespace UMA.Examples
 			}
 			_currentLOD = currentLevel;
 
-			if (_umaData.atlasResolutionScale != atlasResolutionScale)
+         if (atlasResolutionScale < maxReductionf)
+         {
+            atlasResolutionScale = maxReductionf;
+         }
+
+         if (_umaData.atlasResolutionScale != atlasResolutionScale)
 			{
 				_umaData.atlasResolutionScale = atlasResolutionScale;
 				bool changedSlots = ProcessRecipe(currentLevel);


### PR DESCRIPTION
On Hair shaders, changed the default Shader Queue to 3000 (transparent) in the shaders. Also because some versions of Unity reset it on the material (bug), also changed the materials to 3000.

I also tagged in a quick fix for UMASimpleLOD - I created a property to set the maximum LOD level for textures (default is 8). So (for example) the  smallest a 2048x2048 texture can be LOD'ed to is 16x16.  