### PR TITLE
Use Graphics.DrawTexture instead of rendering with camera

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/TextureMerge.prefab
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/TextureMerge.prefab
@@ -3,13 +3,13 @@
 --- !u!1 &100002
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 400002}
   - component: {fileID: 11400000}
-  - component: {fileID: 20188471003643478}
   - component: {fileID: 114351500777494888}
   m_Layer: 31
   m_Name: TextureMerge
@@ -20,9 +20,10 @@ GameObject:
   m_IsActive: 1
 --- !u!4 &400002
 Transform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100002}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -33,16 +34,16 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &11400000
 MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100002}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2bb565bb3cf87a74589f703e67a3d5f9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  myCamera: {fileID: 20188471003643478}
   material: {fileID: 2100000, guid: 9dcf0ea2079905b4eabed17a904b047c, type: 2}
   normalShader: {fileID: 4800000, guid: 0c7937a991ef0764fb16577ebf24911e, type: 3}
   diffuseShader: {fileID: 4800000, guid: ae83be5246f311646b3043ed012d9d64, type: 3}
@@ -54,58 +55,12 @@ MonoBehaviour:
   normalPostProcesses:
   - {fileID: 114351500777494888}
   dataPostProcesses: []
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 100002}
-  m_IsPrefabParent: 1
---- !u!20 &20188471003643478
-Camera:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 100002}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 2
-  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.3
-  far clip plane: 5
-  field of view: 90
-  orthographic: 1
-  orthographic size: 1
-  m_Depth: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 0
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 0
-  m_AllowMSAA: 1
-  m_ForceIntoRT: 0
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
-  m_StereoMirrorMode: 0
 --- !u!114 &114351500777494888
 MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100002}
   m_Enabled: 0
   m_EditorHideFlags: 0

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureBliter.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureBliter.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+
+public class TextureBliter
+{
+    public static void BlitRect(Rect rect, RenderTexture target, Texture texture, Material material = null)
+    {
+        RenderTexture backup = RenderTexture.active;
+        RenderTexture.active = target;
+        GL.PushMatrix();
+        GL.LoadPixelMatrix(0, target.width, target.height, 0);
+        Graphics.DrawTexture(rect, texture, material);
+        GL.PopMatrix();
+        RenderTexture.active = backup;
+    }
+}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureBliter.cs.meta
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureBliter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e37d2f551df1424384cb27884d0ae65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureMerge.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureMerge.cs
@@ -10,7 +10,6 @@ namespace UMA
 	[ExecuteInEditMode]
 	public class TextureMerge : MonoBehaviour
 	{
-		public Camera myCamera;
 		public Material material;
 		public Shader normalShader;
 		public Shader diffuseShader;
@@ -29,24 +28,6 @@ namespace UMA
 			public Material mat;
 			public Texture tex;
 			public Rect rect;
-		}
-
-		void OnRenderObject()
-		{
-			if (Camera.current != myCamera) return;
-
-			if (textureMergeRects != null)
-			{
-				for (int i = 0; i < textureMergeRectCount; i++)
-				{
-					DrawRect(ref textureMergeRects[i]);
-				}
-			}
-		}
-
-		private void DrawRect(ref TextureMergeRect textureMergeRect)
-		{
-			Graphics.DrawTexture(textureMergeRect.rect, textureMergeRect.tex, textureMergeRect.mat);
 		}
 
 		public void Reset()

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureProcessPROCoroutine.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureProcessPROCoroutine.cs
@@ -4,279 +4,241 @@ using System;
 
 namespace UMA
 {
-	/// <summary>
-	/// Texture processing coroutine using rendertextures for atlas building.
-	/// </summary>
-	[Serializable]
-	public class TextureProcessPROCoroutine : TextureProcessBaseCoroutine
-	{
-		UMAData umaData;
-		RenderTexture destinationTexture;
-		Texture[] resultingTextures;
-		UMAGeneratorBase umaGenerator;
-		Camera renderCamera;
-		bool fastPath=false;
+    /// <summary>
+    /// Texture processing coroutine using rendertextures for atlas building.
+    /// </summary>
+    [Serializable]
+    public class TextureProcessPROCoroutine : TextureProcessBaseCoroutine
+    {
+        UMAData umaData;
+        RenderTexture destinationTexture;
+        Texture[] resultingTextures;
+        UMAGeneratorBase umaGenerator;
+        Camera renderCamera;
+        bool fastPath = false;
 
-		Color emptyCameraBG = new Color(0, 0, 0, 0);
-		Color normalCameraBG = Color.grey;
+        Color emptyCameraBG = new Color(0, 0, 0, 0);
+        Color normalCameraBG = Color.grey;
 
-		/// <summary>
-		/// Setup data for atlas building.
-		/// </summary>
-		/// <param name="_umaData">UMA data.</param>
-		/// <param name="_umaGenerator">UMA generator.</param>
-		public override void Prepare(UMAData _umaData, UMAGeneratorBase _umaGenerator)
-		{
-			umaData = _umaData;
-			umaGenerator = _umaGenerator;
-			if (umaGenerator is UMAGenerator)
-			{
-				fastPath = (umaGenerator as UMAGenerator).fastGeneration;
-			}
-			if (umaData.atlasResolutionScale <= 0) umaData.atlasResolutionScale = 1f;
-		}
+        /// <summary>
+        /// Setup data for atlas building.
+        /// </summary>
+        /// <param name="_umaData">UMA data.</param>
+        /// <param name="_umaGenerator">UMA generator.</param>
+        public override void Prepare(UMAData _umaData, UMAGeneratorBase _umaGenerator)
+        {
+            umaData = _umaData;
+            umaGenerator = _umaGenerator;
+            if (umaGenerator is UMAGenerator)
+            {
+                fastPath = (umaGenerator as UMAGenerator).fastGeneration;
+            }
+            if (umaData.atlasResolutionScale <= 0) umaData.atlasResolutionScale = 1f;
+        }
 
-		protected override void Start()
-		{
+        protected override void Start()
+        {
 
-		}
+        }
 
-		public static RenderTexture ResizeRenderTexture(RenderTexture source, int newWidth, int newHeight, FilterMode filter)
-		{
-			source.filterMode = filter;
-			RenderTexture rt = new RenderTexture(newWidth, newHeight, 0, source.format, RenderTextureReadWrite.Linear);
+        public static RenderTexture ResizeRenderTexture(RenderTexture source, int newWidth, int newHeight, FilterMode filter)
+        {
+            source.filterMode = filter;
+            RenderTexture rt = new RenderTexture(newWidth, newHeight, 0, source.format, RenderTextureReadWrite.Linear);
 
-			rt.filterMode = FilterMode.Point;
+            rt.filterMode = FilterMode.Point;
 
-			RenderTexture.active = rt;
-			Graphics.Blit(source, rt);
-			return rt;
-		}
+            RenderTexture.active = rt;
+            Graphics.Blit(source, rt);
+            return rt;
+        }
 
-	  protected override IEnumerator workerMethod()
-	  {
-		 var textureMerge = umaGenerator.textureMerge;
+        protected override IEnumerator workerMethod()
+        {
+            var textureMerge = umaGenerator.textureMerge;
 
-		 for (int atlasIndex = umaData.generatedMaterials.materials.Count - 1; atlasIndex >= 0; atlasIndex--)
-		 {
-			var atlas = umaData.generatedMaterials.materials[atlasIndex];
+            for (int atlasIndex = umaData.generatedMaterials.materials.Count - 1; atlasIndex >= 0; atlasIndex--)
+            {
+                var atlas = umaData.generatedMaterials.materials[atlasIndex];
 
-			//Rendering Atlas
-			int moduleCount = 0;
+                //Rendering Atlas
+                int moduleCount = 0;
 
-			//Process all necessary TextureModules
-			for (int i = 0; i < atlas.materialFragments.Count; i++)
-			{
-			   if (!atlas.materialFragments[i].isRectShared)
-			   {
-				  moduleCount++;
-				  moduleCount = moduleCount + atlas.materialFragments[i].overlays.Length;
-			   }
-			}
-			textureMerge.EnsureCapacity(moduleCount);
-
-			var slotData = atlas.materialFragments[0].slotData;
-			resultingTextures = new Texture[slotData.asset.material.channels.Length];
-			for (int textureType = slotData.asset.material.channels.Length - 1; textureType >= 0; textureType--)
-			{
-			   switch (slotData.asset.material.channels[textureType].channelType)
-			   {
-				  case UMAMaterial.ChannelType.Texture:
-				  case UMAMaterial.ChannelType.DiffuseTexture:
-				  case UMAMaterial.ChannelType.NormalMap:
-				  {
-					 textureMerge.Reset();
-					 for (int i = 0; i < atlas.materialFragments.Count; i++)
-					 {
-						textureMerge.SetupModule(atlas, i, textureType);
-					 }
-
-					 //last element for this textureType
-					 moduleCount = 0;
-
-					 umaGenerator.textureMerge.gameObject.SetActive(true);
-
-					 int width = Mathf.FloorToInt(atlas.cropResolution.x);
-					 int height = Mathf.FloorToInt(atlas.cropResolution.y);
-					 destinationTexture = new RenderTexture(Mathf.FloorToInt(atlas.cropResolution.x * umaData.atlasResolutionScale), Mathf.FloorToInt(atlas.cropResolution.y * umaData.atlasResolutionScale), 0, slotData.asset.material.channels[textureType].textureFormat, RenderTextureReadWrite.Linear);
-					 destinationTexture.filterMode = FilterMode.Point;
-					 destinationTexture.useMipMap = umaGenerator.convertMipMaps && !umaGenerator.convertRenderTexture;
-					 renderCamera = umaGenerator.textureMerge.myCamera;
-
-                    if (slotData.asset.material.channels[textureType].channelType == UMAMaterial.ChannelType.NormalMap)
+                //Process all necessary TextureModules
+                for (int i = 0; i < atlas.materialFragments.Count; i++)
+                {
+                    if (!atlas.materialFragments[i].isRectShared)
                     {
-                        if (QualitySettings.desiredColorSpace == ColorSpace.Linear)
-                        {
-                            //Due to a weird conversion, we need the camera background to be grey in gamme color space.
-                            renderCamera.backgroundColor = normalCameraBG.gamma;
-                        }
-                        else
-                        {
-                            renderCamera.backgroundColor = normalCameraBG;
-                        }                                    
+                        moduleCount++;
+                        moduleCount = moduleCount + atlas.materialFragments[i].overlays.Length;
                     }
-                    else
+                }
+                textureMerge.EnsureCapacity(moduleCount);
+
+                var slotData = atlas.materialFragments[0].slotData;
+                resultingTextures = new Texture[slotData.asset.material.channels.Length];
+                for (int textureType = slotData.asset.material.channels.Length - 1; textureType >= 0; textureType--)
+                {
+                    switch (slotData.asset.material.channels[textureType].channelType)
                     {
-                        renderCamera.backgroundColor = emptyCameraBG;
+                        case UMAMaterial.ChannelType.Texture:
+                        case UMAMaterial.ChannelType.DiffuseTexture:
+                        case UMAMaterial.ChannelType.NormalMap:
+
+                            textureMerge.Reset();
+                            for (int i = 0; i < atlas.materialFragments.Count; i++)
+                            {
+                                textureMerge.SetupModule(atlas, i, textureType);
+                            }
+
+                            //last element for this textureType
+                            moduleCount = 0;
+
+
+                            destinationTexture = new RenderTexture(Mathf.FloorToInt(atlas.cropResolution.x * umaData.atlasResolutionScale), Mathf.FloorToInt(atlas.cropResolution.y * umaData.atlasResolutionScale), 0, slotData.asset.material.channels[textureType].textureFormat, RenderTextureReadWrite.Linear);
+                            destinationTexture.filterMode = FilterMode.Point;
+                            destinationTexture.useMipMap = umaGenerator.convertMipMaps && !umaGenerator.convertRenderTexture;
+
+                            for (int i = 0; i < atlas.materialFragments.Count; i++)
+                            {
+                                var mergeRect = textureMerge.textureMergeRects[i];
+                                if (mergeRect.tex != null)
+                                    TextureBliter.BlitRect(mergeRect.rect, destinationTexture, mergeRect.tex, mergeRect.mat);
+                            }
+
+                            if (umaGenerator.convertRenderTexture || slotData.asset.material.channels[textureType].ConvertRenderTexture)
+                            {
+                                #region Convert Render Textures
+                                if (!fastPath) yield return 25;
+                                Texture2D tempTexture;
+
+                                tempTexture = new Texture2D(destinationTexture.width, destinationTexture.height, TextureFormat.ARGB32, umaGenerator.convertMipMaps, true);
+
+                                int xblocks = destinationTexture.width / 512;
+                                int yblocks = destinationTexture.height / 512;
+                                if (xblocks == 0 || yblocks == 0 || fastPath)
+                                {
+                                    RenderTexture.active = destinationTexture;
+                                    tempTexture.ReadPixels(new Rect(0, 0, destinationTexture.width, destinationTexture.height), 0, 0, umaGenerator.convertMipMaps);
+                                    RenderTexture.active = null;
+                                }
+                                else
+                                {
+                                    // figures that ReadPixels works differently on OpenGL and DirectX, someday this code will break because Unity fixes this bug!
+                                    if (IsOpenGL())
+                                    {
+                                        for (int x = 0; x < xblocks; x++)
+                                        {
+                                            for (int y = 0; y < yblocks; y++)
+                                            {
+                                                RenderTexture.active = destinationTexture;
+                                                tempTexture.ReadPixels(new Rect(x * 512, y * 512, 512, 512), x * 512, y * 512, umaGenerator.convertMipMaps);
+                                                RenderTexture.active = null;
+                                                yield return 8;
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        for (int x = 0; x < xblocks; x++)
+                                        {
+                                            for (int y = 0; y < yblocks; y++)
+                                            {
+                                                RenderTexture.active = destinationTexture;
+                                                tempTexture.ReadPixels(new Rect(x * 512, destinationTexture.height - 512 - y * 512, 512, 512), x * 512, y * 512, umaGenerator.convertMipMaps);
+                                                RenderTexture.active = null;
+                                                yield return 8;
+                                            }
+                                        }
+                                    }
+                                }
+
+
+                                resultingTextures[textureType] = tempTexture as Texture;
+
+                                renderCamera.targetTexture = null;
+                                RenderTexture.active = null;
+
+                                destinationTexture.Release();
+                                UnityEngine.GameObject.DestroyImmediate(destinationTexture);
+                                umaGenerator.textureMerge.gameObject.SetActive(false);
+                                if (!fastPath) yield return 6;
+                                tempTexture = resultingTextures[textureType] as Texture2D;
+                                tempTexture.Apply();
+                                tempTexture.wrapMode = TextureWrapMode.Repeat;
+                                tempTexture.anisoLevel = slotData.asset.material.AnisoLevel;
+                                tempTexture.mipMapBias = slotData.asset.material.MipMapBias;
+                                tempTexture.filterMode = slotData.asset.material.MatFilterMode;
+                                if (slotData.asset.material.channels[textureType].Compression != UMAMaterial.CompressionSettings.None)
+                                {
+                                    tempTexture.Compress(slotData.asset.material.channels[textureType].Compression == UMAMaterial.CompressionSettings.HighQuality);
+                                }
+                                resultingTextures[textureType] = tempTexture;
+                                atlas.material.SetTexture(slotData.asset.material.channels[textureType].materialPropertyName, tempTexture);
+                                #endregion
+                            }
+                            else
+                            {
+                                destinationTexture.anisoLevel = slotData.asset.material.AnisoLevel;
+                                destinationTexture.mipMapBias = slotData.asset.material.MipMapBias;
+                                destinationTexture.filterMode = slotData.asset.material.MatFilterMode;
+                                destinationTexture.wrapMode = TextureWrapMode.Repeat;
+                                resultingTextures[textureType] = destinationTexture;
+                                atlas.material.SetTexture(slotData.asset.material.channels[textureType].materialPropertyName, destinationTexture);
+                            }
+
+                            break;
+
+                        case UMAMaterial.ChannelType.MaterialColor:
+
+                            atlas.material.SetColor(slotData.asset.material.channels[textureType].materialPropertyName, atlas.materialFragments[0].baseColor);
+                            break;
+
+                        case UMAMaterial.ChannelType.TintedTexture:
+
+                            for (int i = 0; i < atlas.materialFragments.Count; i++)
+                            {
+                                var fragment = atlas.materialFragments[i];
+                                if (fragment.isRectShared) continue;
+                                for (int j = 0; j < fragment.baseOverlay.textureList.Length; j++)
+                                {
+                                    if (fragment.baseOverlay.textureList[j] != null)
+                                    {
+                                        atlas.material.SetTexture(slotData.asset.material.channels[j].materialPropertyName, fragment.baseOverlay.textureList[j]);
+                                        if (j == 0)
+                                        {
+                                            atlas.material.color = fragment.baseColor;
+                                        }
+                                    }
+                                }
+                                foreach (var overlay in fragment.overlays)
+                                {
+                                    for (int j = 0; j < overlay.textureList.Length; j++)
+                                    {
+                                        if (overlay.textureList[j] != null)
+                                        {
+                                            atlas.material.SetTexture(slotData.asset.material.channels[j].materialPropertyName, overlay.textureList[j]);
+                                        }
+                                    }
+                                }
+                            }
+                            break;
+
                     }
-                               
+                }
+                atlas.resultingAtlasList = resultingTextures;
+            }
+        }
 
-					 renderCamera.targetTexture = destinationTexture;
-					 renderCamera.orthographicSize = height >> 1;
-					 var camTransform = renderCamera.GetComponent<Transform>();
-					 camTransform.position = new Vector3(width >> 1, height >> 1, 3);
-					 camTransform.rotation = Quaternion.Euler(0, 180, 180);
-					 renderCamera.Render();
+        private bool IsOpenGL()
+        {
+            var graphicsDeviceVersion = SystemInfo.graphicsDeviceVersion;
+            return graphicsDeviceVersion.StartsWith("OpenGL");
+        }
 
-					 int DownSample = slotData.asset.material.channels[textureType].DownSample;
+        protected override void Stop()
+        {
 
-					 if (DownSample != 0)
-					 {
-						int newW = width >> DownSample;
-						int newH = height >> DownSample;
-
-						RenderTexture rt = ResizeRenderTexture(destinationTexture, newW, newH, FilterMode.Bilinear);
-						destinationTexture.Release();
-						destinationTexture = rt;
-					 }
-
-					 renderCamera.gameObject.SetActive(false);
-					 renderCamera.targetTexture = null;
-
-					 if (umaGenerator.convertRenderTexture || slotData.asset.material.channels[textureType].ConvertRenderTexture)
-					 {
-						#region Convert Render Textures
-						if (!fastPath) yield return 25;
-						Texture2D tempTexture;
-
-						tempTexture = new Texture2D(destinationTexture.width, destinationTexture.height, TextureFormat.ARGB32, umaGenerator.convertMipMaps, true);
-
-						int xblocks = destinationTexture.width / 512;
-						int yblocks = destinationTexture.height / 512;
-						if (xblocks == 0 || yblocks == 0 || fastPath)
-						{
-						   RenderTexture.active = destinationTexture;
-						   tempTexture.ReadPixels(new Rect(0, 0, destinationTexture.width, destinationTexture.height), 0, 0, umaGenerator.convertMipMaps);
-						   RenderTexture.active = null;
-						}
-						else
-						{
-						   // figures that ReadPixels works differently on OpenGL and DirectX, someday this code will break because Unity fixes this bug!
-						   if (IsOpenGL())
-						   {
-							  for (int x = 0; x < xblocks; x++)
-							  {
-								 for (int y = 0; y < yblocks; y++)
-								 {
-									RenderTexture.active = destinationTexture;
-									tempTexture.ReadPixels(new Rect(x * 512, y * 512, 512, 512), x * 512, y * 512, umaGenerator.convertMipMaps);
-									RenderTexture.active = null;
-									yield return 8;
-								 }
-							  }
-						   }
-						   else
-						   {
-							  for (int x = 0; x < xblocks; x++)
-							  {
-								 for (int y = 0; y < yblocks; y++)
-								 {
-									RenderTexture.active = destinationTexture;
-									tempTexture.ReadPixels(new Rect(x * 512, destinationTexture.height - 512 - y * 512, 512, 512), x * 512, y * 512, umaGenerator.convertMipMaps);
-									RenderTexture.active = null;
-									yield return 8;
-								 }
-							  }
-						   }
-						}
-
-
-						resultingTextures[textureType] = tempTexture as Texture;
-
-						renderCamera.targetTexture = null;
-						RenderTexture.active = null;
-
-						destinationTexture.Release();
-						UnityEngine.GameObject.DestroyImmediate(destinationTexture);
-						umaGenerator.textureMerge.gameObject.SetActive(false);
-						if (!fastPath) yield return 6;
-						tempTexture = resultingTextures[textureType] as Texture2D;
-						tempTexture.Apply();
-						tempTexture.wrapMode = TextureWrapMode.Repeat;
-						tempTexture.anisoLevel = slotData.asset.material.AnisoLevel;
-						tempTexture.mipMapBias = slotData.asset.material.MipMapBias;
-						tempTexture.filterMode = slotData.asset.material.MatFilterMode;
-						if (slotData.asset.material.channels[textureType].Compression != UMAMaterial.CompressionSettings.None)
-						{
-						   tempTexture.Compress(slotData.asset.material.channels[textureType].Compression == UMAMaterial.CompressionSettings.HighQuality);
-						}
-						resultingTextures[textureType] = tempTexture;
-						atlas.material.SetTexture(slotData.asset.material.channels[textureType].materialPropertyName, tempTexture);
-						#endregion
-					 }
-					 else
-					 {
-						destinationTexture.anisoLevel = slotData.asset.material.AnisoLevel;
-						destinationTexture.mipMapBias = slotData.asset.material.MipMapBias;
-						destinationTexture.filterMode = slotData.asset.material.MatFilterMode;
-						destinationTexture.wrapMode = TextureWrapMode.Repeat;
-						resultingTextures[textureType] = destinationTexture;
-						atlas.material.SetTexture(slotData.asset.material.channels[textureType].materialPropertyName, destinationTexture);
-					 }
-
-					 umaGenerator.textureMerge.gameObject.SetActive(false);
-					 break;
-				  }
-				  case UMAMaterial.ChannelType.MaterialColor:
-				  {
-					 atlas.material.SetColor(slotData.asset.material.channels[textureType].materialPropertyName, atlas.materialFragments[0].baseColor);
-					 break;
-				  }
-				  case UMAMaterial.ChannelType.TintedTexture:
-				  {
-					 for (int i = 0; i < atlas.materialFragments.Count; i++)
-					 {
-						var fragment = atlas.materialFragments[i];
-						if (fragment.isRectShared) continue;
-						for (int j = 0; j < fragment.baseOverlay.textureList.Length; j++)
-						{
-						   if (fragment.baseOverlay.textureList[j] != null)
-						   {
-							  atlas.material.SetTexture(slotData.asset.material.channels[j].materialPropertyName, fragment.baseOverlay.textureList[j]);
-							  if (j == 0)
-							  {
-								 atlas.material.color = fragment.baseColor;
-							  }
-						   }
-						}
-						foreach (var overlay in fragment.overlays)
-						{
-						   for (int j = 0; j < overlay.textureList.Length; j++)
-						   {
-							  if (overlay.textureList[j] != null)
-							  {
-								 atlas.material.SetTexture(slotData.asset.material.channels[j].materialPropertyName, overlay.textureList[j]);
-							  }
-						   }
-						}
-					 }
-					 break;
-				  }
-			   }
-			}
-			atlas.resultingAtlasList = resultingTextures;
-		 }
-	  }
-
-	  private bool IsOpenGL()
-		{
-			var graphicsDeviceVersion = SystemInfo.graphicsDeviceVersion;
-			return graphicsDeviceVersion.StartsWith("OpenGL");
-		}
-
-		protected override void Stop()
-		{
-			
-		}
-	}
+        }
+    }
 }


### PR DESCRIPTION
Hi, I have got UMA working in HDRP, which require changing the way UMA overlay texture
This pull request only contain the core changes.
Check https://github.com/mic-code/UMA/tree/hdrp for working HDRP version
The normal map doesn't got applied to the Lit material until manual refresh (setting the shader to lit again)

![uma](https://user-images.githubusercontent.com/26720201/52290504-26495f80-29ab-11e9-8c62-1a53f633092c.png)
