### PR TITLE
FixUMAAssetBundleManagerSettings bugs

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/UMARandomizer.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/UMARandomizer.cs
@@ -102,6 +102,7 @@ namespace UMA
 		public List<RandomColors> SharedColors;
 		public List<RandomWardrobeSlot> RandomWardrobeSlots;
 		public List<RandomDNA> RandomDna;
+		public RaceData raceData;
 #if UNITY_EDITOR
 		public bool GuiFoldout;
 		public bool ColorsFoldout;
@@ -115,7 +116,7 @@ namespace UMA
 		public int SelectedDNA;
 		public string DNAAdd;
 		public int DNADel;
-		public RaceData raceData;
+		
 #endif
 		public UMAPredefinedDNA GetRandomDNA()
 		{

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/UMAAssetBundleManagerSettings.cs
@@ -494,7 +494,7 @@ namespace UMA.AssetBundles
 #else
 				Caching.CleanCache();          
 #endif
-				return;
+				GUIUtility.ExitGUI();
 			}
 			EndVerticalPadded(5);
 			EditorGUILayout.Space();
@@ -644,27 +644,23 @@ namespace UMA.AssetBundles
 				EditorGUILayout.HelpBox ("Make a testing Build that uses the Local Server using the button below.", MessageType.Info);
 
 				developmentBuild = EditorGUILayout.Toggle ("Development Build", developmentBuild);
-				if (GUILayout.Button ("Build and Run!")) {
-					BuildScript.BuildAndRunPlayer (developmentBuild);
+				if (GUILayout.Button("Build and Run!"))
+				{
+					BuildScript.BuildAndRunPlayer(developmentBuild);
+					GUIUtility.ExitGUI();
 				}
-				if (!showClearCache || !EnableLocalAssetBundleServer) {//
-					EditorGUI.EndDisabledGroup ();
+				else
+				{
+					if (!showClearCache || !EnableLocalAssetBundleServer)
+					{
+						EditorGUI.EndDisabledGroup();
+					}
 				}
-				EditorGUILayout.Space ();
-				EndVerticalPadded (5);
-
-				EditorGUILayout.Space ();
 			}
-			//END SCROLL VIEW
-			//for some reason when we build or build assetbundles when this window is open we get an error
-			//InvalidOperationException: Operation is not valid due to the current state of the object
-			//so try catch is here as a nasty hack to get rid of it
-			try
-			{
-				EditorGUILayout.EndVertical();
-				EditorGUILayout.EndScrollView();
-			}
-			catch { }
+			EditorGUILayout.Space();
+			EndVerticalPadded(5);
+			EditorGUILayout.EndVertical();
+			EditorGUILayout.EndScrollView();
 
 		}
 
@@ -673,35 +669,20 @@ namespace UMA.AssetBundles
 
 		public static void BeginVerticalPadded(float padding, Color backgroundColor)
 		{
-			//for some reason when we build or build assetbundles when this window is open we get an error
-			//InvalidOperationException: Operation is not valid due to the current state of the object
-			//so try catch is here as a nasty hack to get rid of it
-			try
-			{
-				GUI.color = backgroundColor;
-				GUILayout.BeginHorizontal(EditorStyles.textField);
-				GUI.color = Color.white;
-
-				GUILayout.Space(padding);
-				GUILayout.BeginVertical();
-				GUILayout.Space(padding);
-			}
-			catch { }
+			GUI.color = backgroundColor;
+			GUILayout.BeginHorizontal(EditorStyles.textField);
+			GUI.color = Color.white;
+			GUILayout.Space(padding);
+			GUILayout.BeginVertical();
+			GUILayout.Space(padding);
 		}
 
 		public static void EndVerticalPadded(float padding)
 		{
-			//for some reason when we build or build assetbundles when this window is open we get an error
-			//InvalidOperationException: Operation is not valid due to the current state of the object
-			//so try catch is here as a nasty hack to get rid of it
-			try
-			{
-				GUILayout.Space(padding);
-				GUILayout.EndVertical();
-				GUILayout.Space(padding);
-				GUILayout.EndHorizontal();
-			}
-			catch { }
+			GUILayout.Space(padding);
+			GUILayout.EndVertical();
+			GUILayout.Space(padding);
+			GUILayout.EndHorizontal();
 		}
 
 		public static void BeginVerticalIndented(float indentation, Color backgroundColor)

--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/WebServer.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/UMAAssetBundleManager/WebServer.cs
@@ -70,8 +70,8 @@ namespace UMA.AssetBundles
             {
                 if (context.Request.RawUrl == "/")
                 {
-                    if (Debug.isDebugBuild)
-                        Debug.Log("[WebServer] context.Request.RawUrl");
+					//if (Debug.isDebugBuild)//isDebugBuild can only be called from the main thread
+					Debug.Log("[WebServer] context.Request.RawUrl");
                     context.Response.StatusCode = 200;
                     var process = System.Diagnostics.Process.GetCurrentProcess();
                     string msg = string.Format(@"<html><body><h1>UMA Simple Web Server</h1><table>
@@ -174,18 +174,20 @@ namespace UMA.AssetBundles
             {
 				string serverUrlPath = Path.Combine(UMA.FileUtils.GetInternalDataStoreFolder(false, false), "localServerURL.bytes");
 				UMA.FileUtils.WriteAllText(serverUrlPath, _serverURL);
-                AssetDatabase.Refresh();
+				AssetDatabase.Refresh();
             }
         }
         //but we dont want it hanging around afterwards
         public static void DestroyServerURLFile()
         {
 			string serverUrlPath = Path.Combine(UMA.FileUtils.GetInternalDataStoreFolder(false, false), "localServerURL.bytes");
+			string serverUrlMetaPath = Path.Combine(UMA.FileUtils.GetInternalDataStoreFolder(false, false), "localServerURL.bytes.meta");
+			File.Delete(serverUrlMetaPath);
 			File.Delete(serverUrlPath);
-            AssetDatabase.Refresh();
-        }
+			AssetDatabase.Refresh();
+		}
 #endif
-        //because in the editor we dont want this to return anything
+        //because in the editor we dont want this to set anything
         static void GetServerURL()
         {
             TextAsset urlFile = Resources.Load("localServerURL") as TextAsset;


### PR DESCRIPTION
Fixes the localServerURL.bytes file not being deleted after a LocalTestingBuild was generated by UMAAssetBundleManagerSettings- this was preventing normal builds afterwards from downloading the assetbundle index, fixes some outstanding UI errors that occured when building bundles or the player in UMAAssetBundleManagerSettings window, fixes an erroneous editor only field definition in UMARandomizer that was preventing building