### PR TITLE
Fix potential infinite loop with 0 size textures

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorCoroutine.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAGeneratorCoroutine.cs
@@ -330,8 +330,18 @@ namespace UMA
 				var tempMaterialDef = material.materialFragments[atlasElementIndex];
 				if (tempMaterialDef.isRectShared)
 					continue;
-
-				tempMaterialDef.atlasRegion = packTexture.Insert(Mathf.FloorToInt(tempMaterialDef.baseOverlay.textureList[0].width * material.resolutionScale * tempMaterialDef.slotData.overlayScale), Mathf.FloorToInt(tempMaterialDef.baseOverlay.textureList[0].height * material.resolutionScale * tempMaterialDef.slotData.overlayScale), MaxRectsBinPack.FreeRectChoiceHeuristic.RectBestLongSideFit);
+				
+				int width = Mathf.FloorToInt(tempMaterialDef.baseOverlay.textureList[0].width * material.resolutionScale * tempMaterialDef.slotData.overlayScale);
+				int height = Mathf.FloorToInt(tempMaterialDef.baseOverlay.textureList[0].height * material.resolutionScale * tempMaterialDef.slotData.overlayScale);
+				
+				// If either width or height are 0 we will end up with nullRect and potentially loop forever
+				if (width == 0 || height == 0) 
+				{
+					tempMaterialDef.atlasRegion = nullRect;
+					continue;
+				}
+				
+				tempMaterialDef.atlasRegion = packTexture.Insert(width, height, MaxRectsBinPack.FreeRectChoiceHeuristic.RectBestLongSideFit);
 
 				if (tempMaterialDef.atlasRegion == nullRect)
 				{


### PR DESCRIPTION
This can happen when assets get stripped/replaced with empty versions to save on build size for headless builds