### PR TITLE
Don't try to merge 0 size textures

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureProcessPROCoroutine.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureProcessPROCoroutine.cs
@@ -97,7 +97,13 @@ namespace UMA
 					 moduleCount = 0;
 
 					 int width = Mathf.FloorToInt(atlas.cropResolution.x);
-					 int height = Mathf.FloorToInt(atlas.cropResolution.y);
+					 int height = Mathf.FloorToInt(atlas.cropResolution.y);	
+					 
+					 if (width == 0 || height == 0) 
+					 {
+						 continue;
+					 }
+					 
 					 destinationTexture = new RenderTexture(Mathf.FloorToInt(atlas.cropResolution.x * umaData.atlasResolutionScale), Mathf.FloorToInt(atlas.cropResolution.y * umaData.atlasResolutionScale), 0, slotData.asset.material.channels[textureType].textureFormat, RenderTextureReadWrite.Linear);
 					 destinationTexture.filterMode = FilterMode.Point;
 					 destinationTexture.useMipMap = umaGenerator.convertMipMaps && !umaGenerator.convertRenderTexture;


### PR DESCRIPTION
Hey, me again with another tiny change related to removing textures from server builds that don't render anything (sorry, hope this isnt getting too annoying!)

This can happen when assets are replaced with zero sized versions to reduce size for headless builds and cause "RenderTexture.Create failed: width & height must be larger than 0" when the texture is assigned to the camera and more exceptions down the line due to bad state