### PR TITLE
Feature detail normal ch type

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
@@ -17,10 +17,7 @@ SubShader
 {
 	Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
 
-	GrabPass
-    {
-        "_PreviousNormal"
-    }
+	GrabPass { }
 
 	Pass
 	{
@@ -39,11 +36,12 @@ SubShader
 		float4 _AdditiveColor;
 		sampler2D _MainTex;
 		sampler2D _ExtraTex;
-		sampler2D _PreviousNormal;
+		sampler2D _GrabTexture;
 
 		struct v2f {
 			float4  pos : SV_POSITION;
 			float2  uv : TEXCOORD0;
+			float4  grabPos : TEXCOORD1;
 		};
 
 		float4 _MainTex_ST;
@@ -53,6 +51,7 @@ SubShader
 			v2f o;
 			o.pos = UnityObjectToClipPos(v.vertex);
 			o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
+			o.grabPos = ComputeGrabScreenPos(o.pos);
 			return o;
 		}
 
@@ -61,7 +60,7 @@ SubShader
 		half4 frag(v2f i) : COLOR
 		{
 		    // Get previous normal map from grab pass,
-			half4 previous = tex2D(_PreviousNormal, i.uv);
+			half4 previous = tex2Dproj(_GrabTexture, i.grabPos);
 		    // Get current texture and mask textures
 			half4 current = tex2D(_MainTex, i.uv);
 			half4 extra = tex2D(_ExtraTex, i.uv);

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
@@ -77,15 +77,11 @@ SubShader
             half3 blended = BlendNormals(pn, n);
             
             // Re-pack blended normal into texture and return.
-#if defined(UNITY_NO_DXT5nm)
-			return half4((blended.xyz + 1) / 2, 1);
-#else
 			half4 packednormal;
 			packednormal.wy = (blended.xy + 1) / 2;
 			packednormal.x = 1;
 			packednormal.z = 1;
 			return packednormal;
-#endif
 		}
 		ENDCG
 	}

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
@@ -56,17 +56,27 @@ SubShader
 			return o;
 		}
 
+        // This atlas shader has Blend mode Off
+        // It grabs from previous texture and outputs the merged normal map
 		half4 frag(v2f i) : COLOR
 		{
+		    // Get previous normal map from grab pass,
 			half4 previous = tex2D(_PreviousNormal, i.uv);
+		    // Get current texture and mask textures
 			half4 current = tex2D(_MainTex, i.uv);
 			half4 extra = tex2D(_ExtraTex, i.uv);
+            
+            // Unpack previous and current textures with alpha from color/mask as strength
             half3 pn = half3(previous.wy * 2 - 1, 0);
             pn.z = sqrt(1 - saturate(dot(pn.xy, pn.xy)));
             half3 n = half3(current.wy * 2 - 1, 0);
             n.xy *= min(extra.a, _Color.a);
             n.z = sqrt(1 - saturate(dot(n.xy, n.xy)));
+            
+            // Blend them as current normal map being detail on previous one
             half3 blended = BlendNormals(pn, n);
+            
+            // Re-pack blended normal into texture and return.
 #if defined(UNITY_NO_DXT5nm)
 			return half4((blended.xyz + 1) / 2, 1);
 #else

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
@@ -1,0 +1,85 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+//	============================================================
+//	Name:		AtlasShader
+//	Author: 	Joen Joensen (@UnLogick)
+//	============================================================
+
+Shader "UMA/AtlasDetailShaderNormal" {
+Properties {
+	_Color ("Main Color", Color) = (1,1,1,1)
+	_AdditiveColor ("Additive Color", Color) = (0,0,0,0)
+	_MainTex ("Normalmap", 2D) = "bump" {}
+	_ExtraTex ("mask", 2D) = "white" {}
+}
+
+SubShader 
+{
+	Tags {"Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent"}
+
+	GrabPass
+    {
+        "_PreviousNormal"
+    }
+
+	Pass
+	{
+		Tags{ "LightMode" = "Vertex" }
+		Fog{ Mode Off }
+		Blend Off
+		Lighting Off
+		CGPROGRAM
+		#pragma vertex vert
+		#pragma fragment frag
+
+		#include "UnityCG.cginc"
+		#include "UnityStandardUtils.cginc"
+
+		float4 _Color;
+		float4 _AdditiveColor;
+		sampler2D _MainTex;
+		sampler2D _ExtraTex;
+		sampler2D _PreviousNormal;
+
+		struct v2f {
+			float4  pos : SV_POSITION;
+			float2  uv : TEXCOORD0;
+		};
+
+		float4 _MainTex_ST;
+
+		v2f vert(appdata_base v)
+		{
+			v2f o;
+			o.pos = UnityObjectToClipPos(v.vertex);
+			o.uv = TRANSFORM_TEX(v.texcoord, _MainTex);
+			return o;
+		}
+
+		half4 frag(v2f i) : COLOR
+		{
+			half4 previous = tex2D(_PreviousNormal, i.uv);
+			half4 current = tex2D(_MainTex, i.uv);
+			half4 extra = tex2D(_ExtraTex, i.uv);
+            half3 pn = half3(previous.wy * 2 - 1, 0);
+            pn.z = sqrt(1 - saturate(dot(pn.xy, pn.xy)));
+            half3 n = half3(current.wy * 2 - 1, 0);
+            n.xy *= min(extra.a, _Color.a);
+            n.z = sqrt(1 - saturate(dot(n.xy, n.xy)));
+            half3 blended = BlendNormals(pn, n);
+#if defined(UNITY_NO_DXT5nm)
+			return half4((blended.xyz + 1) / 2, 1);
+#else
+			half4 packednormal;
+			packednormal.wy = (blended.xy + 1) / 2;
+			packednormal.x = 1;
+			packednormal.z = 1;
+			return packednormal;
+#endif
+		}
+		ENDCG
+	}
+}
+
+Fallback "Transparent/VertexLit"
+} 

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureMerge.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureMerge.cs
@@ -16,6 +16,7 @@ namespace UMA
 		public Shader diffuseShader;
 		public Shader dataShader;
 		public Shader cutoutShader;
+		public Shader detailNormalShader;
 
 		[System.NonSerialized] 
 		public Color camBackgroundColor = new Color(0, 0, 0, 0);
@@ -23,6 +24,7 @@ namespace UMA
 		public List<UMAPostProcess> diffusePostProcesses = new List<UMAPostProcess>();
 		public List<UMAPostProcess> normalPostProcesses = new List<UMAPostProcess>();
 		public List<UMAPostProcess> dataPostProcesses = new List<UMAPostProcess>();
+		public List<UMAPostProcess> detailNormalPostProcesses = new List<UMAPostProcess>();
 
 		private int textureMergeRectCount;
 		private TextureMergeRect[] textureMergeRects;
@@ -89,6 +91,13 @@ namespace UMA
 						postProcess.Process(source, destination);
 					}
 					break;
+				case UMAMaterial.ChannelType.DetailNormalMap:
+					foreach (UMAPostProcess postProcess in detailNormalPostProcesses)
+					{
+						Graphics.Blit(destination, source);
+						postProcess.Process(source, destination);
+					}
+					break;
 			}
 			RenderTexture.ReleaseTemporary(source);
 		}
@@ -139,6 +148,9 @@ namespace UMA
 					break;
 				case UMAMaterial.ChannelType.DiffuseTexture:
 					textureMergeRect.mat.shader = diffuseShader;
+					break;
+				case UMAMaterial.ChannelType.DetailNormalMap:
+					textureMergeRect.mat.shader = detailNormalShader;
 					break;
 			}
 			textureMergeRect.mat.SetTexture("_MainTex", source.baseOverlay.textureList[textureType]);
@@ -211,6 +223,9 @@ namespace UMA
 						break;
 					case UMAMaterial.ChannelType.DiffuseTexture:
 						textureMergeRect.mat.shader = diffuseShader;
+						break;
+					case UMAMaterial.ChannelType.DetailNormalMap:
+						textureMergeRect.mat.shader = detailNormalShader;
 						break;
 				}
 				textureMergeRect.mat.SetTexture("_MainTex", source.overlays[i2].textureList[textureType]);

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureProcessPROCoroutine.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/TextureProcessPROCoroutine.cs
@@ -86,6 +86,7 @@ namespace UMA
                         case UMAMaterial.ChannelType.Texture:
                         case UMAMaterial.ChannelType.DiffuseTexture:
                         case UMAMaterial.ChannelType.NormalMap:
+                        case UMAMaterial.ChannelType.DetailNormalMap:
                         {
                             textureMerge.Reset();
                             for (int i = 0; i < atlas.materialFragments.Count; i++)

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAMaterial.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAMaterial.cs
@@ -48,6 +48,7 @@ namespace UMA
             MaterialColor = 2,
             TintedTexture = 3,
             DiffuseTexture = 4,
+            DetailNormalMap = 5,
         }
 
 		static public Color GetBackgroundColor(ChannelType channelType)
@@ -63,7 +64,8 @@ namespace UMA
 			Color.grey,
 			new Color(0,0,0,0),
 			new Color(0,0,0,0),
-			new Color(0,0,0,0)
+			new Color(0,0,0,0),
+			new Color(1,0.5f,1,0.5f)
 		};
 
         [Serializable]


### PR DESCRIPTION
Added channel type NormalDetail that can be used to merge the normal maps on detail normal maps. (Like the one on the unity standard shader)

When this channel type is selected for a texture channel then it is merged by the new AtlasDetailNormalShader.shader.