### PR TITLE
Fix issue where adding an AnimatorController to the indexer adds it a…

### DIFF
--- a/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/UMAAssetIndexer.cs
+++ b/UMAProject/Assets/UMA/Core/Extensions/DynamicCharacterSystem/Scripts/UMAAssetIndexer.cs
@@ -2065,7 +2065,7 @@ namespace UMA
         public bool EvilAddAsset(System.Type type, UnityEngine.Object o)
         {
             AssetItem ai = null;
-            ai = new AssetItem(type, o);
+            ai = new AssetItem(TypeToLookup[type], o);
             ai._Path = AssetDatabase.GetAssetPath(o.GetInstanceID());
             return AddAssetItem(ai);
         }


### PR DESCRIPTION
In UMAAssetIndexer.cs, the AnimatorController to RuntimeAnimatorController mapping for the UMAAssetIndexer.TypeToLookup dictionary is ifdefed for UNITY_EDITOR since it is part of the UnityEditor namespace.  When we add an AnimatorController to our UMA Global Library, it sets the AssetItem._BaseTypeName to "AnimatorController".

When a standalone build is made with this, the an KeyNotFoundException is thrown when accessing the AssetItem._Type since AssetItem._BaseTypeName is defined as "AnimatorController" instead of "RuntimeAnimatorController".  In editor this works since we have AnimatorController in the UMAAssetIndexer.TypeToLookup, but in a standalone build this fails.

This change ensures that the AssetItem._BaseTypeName when we add a AnimatorControllor to the UMA Global Library is set the "RuntimeAnimatorController" instead of "AnimatorController", and the AssetIndexer.asset will have a recognized type when it loads the library.