### PR TITLE
Detail normal atlas shader fix for android and default renderer NPE fix

### DIFF
--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Atlas/AtlasDetailNormalShader.shader
@@ -55,23 +55,38 @@ SubShader
 			return o;
 		}
 		
-		inline half3 UNPACK_WITH_WEIGHT_INTERNAL(half4 tobeUnpacked, float weight) {
-		    half3 result = half3(tobeUnpacked.wy * 2 - 1, 1);
-            result.xy *= weight;
-            result.z = sqrt(1 - saturate(dot(result.xy, result.xy)));
-            return normalize(result);
-	    }
+		half3 UNPACK_WITH_WEIGHT_INTERNAL(half4 packednormal, half bumpScale)
+        {
+            #if defined(UNITY_NO_DXT5nm)
+                half3 normal = half3(packednormal.xy * 2 - 1, 1);
+                normal.xy *= bumpScale;
+                normal.z = sqrt(1 - saturate(dot(normal.xy, normal.xy)));
+                return normalize(normal);
+            #else
+                half3 result = half3(packednormal.wy * 2 - 1, 1);
+                result.xy *= bumpScale;
+                result.z = sqrt(1 - saturate(dot(result.xy, result.xy)));
+                return normalize(result);
+            #endif
+        }
 		
 		inline half3 UNPACK_INTERNAL(half4 tobeUnpacked) {
 		    return UNPACK_WITH_WEIGHT_INTERNAL(tobeUnpacked, 1);
 	    }
 	    
 	    inline float4 PACK_INTERNAL(half3 unpacked) {
-	        half4 packednormal;
-			packednormal.wy = (unpacked.xy + 1) / 2;
-			packednormal.x = 1;
-			packednormal.z = 1;
-			return packednormal;
+			#if defined(UNITY_NO_DXT5nm)
+			    half4 packednormal;
+			    packednormal.xyz = (unpacked.xyz + 1) / 2;
+			    packednormal.w = 1;
+                return packednormal;
+            #else
+                half4 packednormal;
+                packednormal.wy = (unpacked.xy + 1) / 2;
+                packednormal.x = 1;
+                packednormal.z = 1;
+                return packednormal;
+            #endif
 	    }
 
         // This atlas shader has Blend mode Off

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAMaterial.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAMaterial.cs
@@ -65,7 +65,7 @@ namespace UMA
 			new Color(0,0,0,0),
 			new Color(0,0,0,0),
 			new Color(0,0,0,0),
-			new Color(1,0.5f,1,0.5f)
+			new Color(0.5f,0.5f,1,0.5f)
 		};
 
         [Serializable]

--- a/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAMeshData.cs
+++ b/UMAProject/Assets/UMA/Core/StandardAssets/UMA/Scripts/UMAMeshData.cs
@@ -198,6 +198,10 @@ namespace UMA
 		}
 		public static BoneWeight[] Convert(UMABoneWeight[] boneWeights)
 		{
+			if (boneWeights == null)
+			{
+				return new BoneWeight[0];
+			}
 			var res = new BoneWeight[boneWeights.Length];
 			for (int i = 0; i < boneWeights.Length; i++)
 			{


### PR DESCRIPTION
#### Changes
- Detail normal atlas shader fix for android. (and one line change for camera background color)
- Fix for null pointer exception when no slots on default UMA renderer left. (Body slots are on a separate renderer and all clothing slots are removed from default renderer.)