### PR TITLE
Single group generator fails gracefully with missing asset

### DIFF
--- a/UMAProject/Assets/UMA/Core/Editor/Scripts/AddressablePlugins/SingleGroupGenerator.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Scripts/AddressablePlugins/SingleGroupGenerator.cs
@@ -140,6 +140,11 @@ namespace UMA
                 StringBuilder sb = new StringBuilder();
                 foreach (AssetItem ai in AddressableItems.Keys)
                 {
+                    if (!ai.Item)
+                    {
+                        Debug.LogError($"Asset \"{ai._Name}\" of type \"{ai._Type}\" doesn't exist anymore - did it get deleted?");
+                        continue;
+                    }
                     ai.IsAddressable = true;
                     ai.AddressableAddress = ""; // let the system assign it if we are generating.
                     ai.AddressableGroup = sharedGroup.name;


### PR DESCRIPTION
Previously it'd just throw an npe which would cancel the group generation without letting you know what asset the issue was if an asset was missing

The multi-group generator handles this fine and logs errors as expected from my testing