### PR TITLE
Added specific culture settings for obj strings

### DIFF
--- a/UMAProject/Assets/UMA/Core/Editor/Scripts/UMAObjExporter.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Scripts/UMAObjExporter.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Text;
+using System.Globalization;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -18,17 +19,17 @@ namespace UMA.Editors
 			sb.Append("g ").Append(m.name).Append("\n");
 			foreach (Vector3 v in m.vertices)
 			{
-				sb.Append(string.Format("v {0} {1} {2}\n", v.x, v.y, v.z));
+				sb.Append(string.Format(CultureInfo.InvariantCulture, "v {0} {1} {2}\n", v.x, v.y, v.z));
 			}
 			sb.Append("\n");
 			foreach (Vector3 v in m.normals)
 			{
-				sb.Append(string.Format("vn {0} {1} {2}\n", v.x, v.y, v.z));
+				sb.Append(string.Format(CultureInfo.InvariantCulture, "vn {0} {1} {2}\n", v.x, v.y, v.z));
 			}
 			sb.Append("\n");
 			foreach (Vector3 v in m.uv)
 			{
-				sb.Append(string.Format("vt {0} {1}\n", v.x, v.y));
+				sb.Append(string.Format(CultureInfo.InvariantCulture, "vt {0} {1}\n", v.x, v.y));
 			}
 			for (int material = 0; material < m.subMeshCount; material++)
 			{


### PR DESCRIPTION
When exporting an avatar as obj file using this class, in some machines the float values for vertices, normals and uv could end up written with a comma (",") as separator instead of a period ("."). That would make the resulting obj file not readable by most editor/viewer applications. This fix solves that issues.