### PR TITLE
fix: use fully qualified name for NamedBuildTarget in ShaderPackage

### DIFF
--- a/UMAProject/Assets/UMA/Core/ShaderPackages/ShaderPackager-main/Scripts/Editor/ShaderPackage.cs
+++ b/UMAProject/Assets/UMA/Core/ShaderPackages/ShaderPackager-main/Scripts/Editor/ShaderPackage.cs
@@ -18,7 +18,7 @@ namespace UMA.ShaderPackager
             get
             {
 #if UNITY_SERVER
-                    return NamedBuildTarget.Server;
+                    return UnityEditor.Build.NamedBuildTarget.Server;
 #else
                 BuildTarget buildTarget = EditorUserBuildSettings.activeBuildTarget;
                 BuildTargetGroup targetGroup = BuildPipeline.GetBuildTargetGroup(buildTarget);


### PR DESCRIPTION
Fixes Assets/UMA/Core/ShaderPackages/ShaderPackager-main/Scripts/Editor/ShaderPackage.cs(21,28): error CS0103: The name 'NamedBuildTarget' does not exist in the current context during UNITY_SERVER builds