### PR TITLE
Fixed empty list Dna field becoming null upon unmarshalling

### DIFF
--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/AvatarDefinition.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/AvatarDefinition.cs
@@ -357,21 +357,18 @@ namespace UMA
                         // Unpack DNA
                         splitter[0] = ';';
                         string[] Dna = s.Substring(2).Trim().Split(splitter, StringSplitOptions.RemoveEmptyEntries);
-                        if (Dna.Length > 0)
+                        List<DnaDef> theDna = new List<DnaDef>();
+                        foreach (string d in Dna)
                         {
-                            List<DnaDef> theDna = new List<DnaDef>();
-                            foreach (string d in Dna)
+                            splitter[0] = '=';
+                            string[] dnaval = d.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
+                            if (dnaval.Length > 1)
                             {
-                                splitter[0] = '=';
-                                string[] dnaval = d.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
-                                if (dnaval.Length > 1)
-                                {
-                                    DnaDef newDna = new DnaDef(dnaval[0], Convert.ToInt32(dnaval[1], 16));
-                                    theDna.Add(newDna);
-                                }
+                                DnaDef newDna = new DnaDef(dnaval[0], Convert.ToInt32(dnaval[1], 16));
+                                theDna.Add(newDna);
                             }
-                            adf.Dna = theDna.ToArray();
                         }
+                        adf.Dna = theDna.ToArray();
                         break;
                 }
             }
@@ -415,22 +412,20 @@ namespace UMA
                         // Unpack DNA
                         splitter[0] = ';';
                         string[] Dna = s.Substring(2).Trim().Split(splitter, StringSplitOptions.RemoveEmptyEntries);
-                        if (Dna.Length > 0)
+                        List<DnaDef> theDna = new List<DnaDef>();
+                        for (int i1 = 0; i1 < Dna.Length; i1++)
                         {
-                            List<DnaDef> theDna = new List<DnaDef>();
-                            for (int i1 = 0; i1 < Dna.Length; i1++)
+                            string d = Dna[i1];
+                            splitter[0] = '=';
+                            string[] dnaval = d.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
+                            if (dnaval.Length > 1)
                             {
-                                string d = Dna[i1];
-                                splitter[0] = '=';
-                                string[] dnaval = d.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
-                                if (dnaval.Length > 1)
-                                {
-                                    DnaDef newDna = new DnaDef(dnaval[0], Convert.ToInt32(dnaval[1], 16));
-                                    theDna.Add(newDna);
-                                }
+                                DnaDef newDna = new DnaDef(dnaval[0], Convert.ToInt32(dnaval[1], 16));
+                                theDna.Add(newDna);
                             }
-                            adf.Dna = theDna.ToArray();
                         }
+                        adf.Dna = theDna.ToArray();
+                        
                         break;
                 }
             }


### PR DESCRIPTION
If AvatarDefinition's Dna field is empty list (meaning no DNA change applied), 
upon using `ToCompressedString` then revert it with `FromCompressedString`,
I expect it should be an empty list again, but currently it becomes null instead.

For example
```
// Consider `avatar` a DynamicCharacterAvatar that has no custom DNA applied over the default DNA values
AvatarDefinition adf = avatar.GetAvatarDefinition(true);
Debug.Log(adf.Dna.Count); // => 0
string data = adf.ToCompressedString("|");
AvatarDefinition unmarshalledAdf = AvatarDefinition.FromCompressedString(data);
Debug.Log(unmarshalledAdf.Dna.Count); // Error Null exception (unmarshalledAdf.Dna is null)
```

This fixes it by removing the `if (Dna.Length > 0)` condition to trigger adf.Dna's assignment


