### PR TITLE
Add optional Sprite Atlas V2 generation to Icon Creator

### DIFF
--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -634,14 +634,7 @@ public class IconCreator : MonoBehaviour
 
     private static void DestroyDetachedRecipe(UMAWardrobeRecipe recipe)
     {
-        if (Application.isPlaying)
-        {
-            Destroy(recipe);
-        }
-        else
-        {
-            DestroyImmediate(recipe);
-        }
+        UMAUtils.DestroySceneObject(recipe);
     }
 
     private static void UnloadThumbnailAsset(string assetPath)
@@ -1237,18 +1230,7 @@ public class IconCreator : MonoBehaviour
 
     private static void DestroyTexture(Texture2D texture)
     {
-#if UNITY_EDITOR
-        if (Application.isPlaying)
-        {
-            Destroy(texture);
-        }
-        else
-        {
-            DestroyImmediate(texture);
-        }
-#else
-        Destroy(texture);
-#endif
+        UMAUtils.DestroySceneObject(texture);
     }
 
     private int GetCaptureSupersampling()

--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -294,6 +294,8 @@ public class IconCreator : MonoBehaviour
         public string AssetPath;
     }
 
+    // Owns the temporary reference changes required to release Unity's handles on thumbnails.
+    // Dispose restores those references and managed atlases even when rendering is interrupted.
     private sealed class ThumbnailGenerationSession : IDisposable
     {
         private readonly List<ThumbnailGenerationItem> items;
@@ -562,6 +564,8 @@ public class IconCreator : MonoBehaviour
         List<ThumbnailGenerationItem> items,
         List<ThumbnailReferenceSnapshot> references)
     {
+        // UnloadUnusedAssets cannot release a thumbnail while a loaded recipe still references it.
+        // Only references to files being regenerated are cleared, and the session restores them by path.
         var outputAssetPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (int i = 0; i < items.Count; i++)
         {
@@ -617,6 +621,8 @@ public class IconCreator : MonoBehaviour
 
     private static UMAWardrobeRecipe CreateDetachedRecipe(UMAWardrobeRecipe sourceRecipe)
     {
+        // Rendering uses a transient clone so the source recipe can release its thumbnail Sprite
+        // without removing the wardrobe data needed to build the character.
         UMAWardrobeRecipe renderRecipe = Instantiate(sourceRecipe);
         try
         {
@@ -650,6 +656,8 @@ public class IconCreator : MonoBehaviour
 
     private void ReleaseManagedThumbnailAtlases(List<string> atlasAssetPaths)
     {
+        // A loaded atlas can retain the source Sprite after recipe references are cleared. Unload only
+        // atlases created under this Icon Creator root, then reload them when the session is disposed.
         string atlasFolder = GetManagedAtlasAssetFolder();
         UnityEngine.U2D.SpriteAtlas[] loadedAtlases =
             Resources.FindObjectsOfTypeAll<UnityEngine.U2D.SpriteAtlas>();
@@ -1009,6 +1017,8 @@ public class IconCreator : MonoBehaviour
         string outputFolder)
     {
 #if UNITY_EDITOR
+        // Reuse an existing thumbnail in the configured output folder so its filename, .meta file,
+        // and GUID remain stable. The GUID-based name is only for a thumbnail with no reusable file.
         string existingAssetPath = GetExistingThumbnailAssetPath(uwr, raceName);
         string existingAbsolutePath = GetAbsoluteAssetPath(existingAssetPath);
         if (IsFileInFolder(existingAbsolutePath, outputFolder))
@@ -1106,6 +1116,8 @@ public class IconCreator : MonoBehaviour
 
         RenderTexture originalTarget = captureCamera.targetTexture;
         Vector2Int iconDimensions = GetIconDimensions();
+        // Render above the requested icon size, then filter back to the final dimensions. The camera's
+        // serialized target remains untouched, and the temporary allocation is capped by the GPU limit.
         int maxSupersampling = Mathf.Max(
             1,
             SystemInfo.maxTextureSize / Mathf.Max(iconDimensions.x, iconDimensions.y));
@@ -1182,6 +1194,8 @@ public class IconCreator : MonoBehaviour
 #if UNITY_EDITOR
         AssetDatabase.ReleaseCachedFileHandles();
 #endif
+        // Replace the PNG atomically while leaving its Unity .meta file in place. Unity or a file scanner
+        // can briefly reopen imported assets on Windows, so sharing failures are retried with backoff.
         string temporaryPath = outputPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
         try
         {

--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -285,10 +285,8 @@ public class IconCreator : MonoBehaviour
         var recipes = avatar.AvailableRecipes;
         if (recipes != null && recipes.TryGetValue(region, out List<UMATextRecipe> regionRecipes))
         {
-            int sequence = 0;
             foreach (var recipe in regionRecipes)
             {
-                sequence++;
                 var uwr = recipe as UMAWardrobeRecipe;
                 if (uwr != null)
                 {
@@ -296,7 +294,7 @@ public class IconCreator : MonoBehaviour
                     if (uwr.thumbnailFromTexture)
                     {
                         string raceName = avatar.activeRace.racedata.raceName;
-                        string textureOutputPath = GenerateThumbnailFromRecipeTexture(uwr, region, raceName, sequence);
+                        string textureOutputPath = GenerateThumbnailFromRecipeTexture(uwr, region, raceName);
                         if (!string.IsNullOrEmpty(textureOutputPath))
                         {
 #if UNITY_EDITOR
@@ -343,7 +341,7 @@ public class IconCreator : MonoBehaviour
                     }
 
                     string outputFolder = GetOutputFolder(region, avatar.activeRace.racedata.raceName);
-                    string outputPath = Path.Combine(outputFolder, SanitizePathSegment(sequence + "_" + uwr.name) + ".png");
+                    string outputPath = Path.Combine(outputFolder, GetThumbnailFileName(uwr));
                     if (!CaptureRenderTextureToPng(cameraRegions.camera, outputPath))
                     {
                         currentStatus = $"Failed to capture icon for recipe: {uwr.name}";
@@ -371,7 +369,7 @@ public class IconCreator : MonoBehaviour
         }
     }
 
-    private string GenerateThumbnailFromRecipeTexture(UMAWardrobeRecipe uwr, string region, string raceName, int sequence)
+    private string GenerateThumbnailFromRecipeTexture(UMAWardrobeRecipe uwr, string region, string raceName)
     {
         if (uwr == null)
         {
@@ -416,8 +414,13 @@ public class IconCreator : MonoBehaviour
         }
 
         Texture sourceTexture = textureList[0];
-        Texture2D readableTexture = GetReadableTexture2D(sourceTexture);
-        if (readableTexture == null)
+        Vector2Int iconDimensions = GetIconDimensions();
+        Texture2D outputTexture = GetReadableTexture2D(
+            sourceTexture,
+            uwr.thumbnailRect,
+            iconDimensions.x,
+            iconDimensions.y);
+        if (outputTexture == null)
         {
             Debug.LogWarning($"IconCreator: Failed to get readable texture for recipe '{uwr.name}'.");
             return null;
@@ -425,73 +428,75 @@ public class IconCreator : MonoBehaviour
 
         try
         {
-            // Crop using thumbnailRect (normalized UV coordinates, 0-1 range)
-            Rect thumbnailRect = uwr.thumbnailRect;
-            int srcWidth = readableTexture.width;
-            int srcHeight = readableTexture.height;
-
-            int cropX = Mathf.RoundToInt(thumbnailRect.x * srcWidth);
-            int cropY = Mathf.RoundToInt(thumbnailRect.y * srcHeight);
-            int cropWidth = Mathf.RoundToInt(thumbnailRect.width * srcWidth);
-            int cropHeight = Mathf.RoundToInt(thumbnailRect.height * srcHeight);
-
-            // Clamp to valid range
-            cropX = Mathf.Clamp(cropX, 0, srcWidth - 1);
-            cropY = Mathf.Clamp(cropY, 0, srcHeight - 1);
-            cropWidth = Mathf.Clamp(cropWidth, 1, srcWidth - cropX);
-            cropHeight = Mathf.Clamp(cropHeight, 1, srcHeight - cropY);
-
-            Color[] pixels = readableTexture.GetPixels(cropX, cropY, cropWidth, cropHeight);
-
-            // Create output texture and convert to grayscale with brightness/contrast
-            Texture2D outputTexture = new Texture2D(cropWidth, cropHeight, TextureFormat.RGBA32, false);
-            Color[] outputPixels = new Color[pixels.Length];
-            for (int i = 0; i < pixels.Length; i++)
+            Color[] outputPixels = outputTexture.GetPixels();
+            for (int i = 0; i < outputPixels.Length; i++)
             {
-                float gray = pixels[i].grayscale;
+                float gray = outputPixels[i].grayscale;
                 gray = ApplyBrightnessContrast(gray, brightness, contrast);
-                outputPixels[i] = new Color(gray, gray, gray, pixels[i].a);
+                outputPixels[i] = new Color(gray, gray, gray, outputPixels[i].a);
             }
             outputTexture.SetPixels(outputPixels);
             outputTexture.Apply();
 
-            // Save to PNG
             string outputFolder = GetOutputFolder(region, raceName);
-            string outputPath = Path.Combine(outputFolder, SanitizePathSegment(sequence + "_" + uwr.name) + ".png");
+            string outputPath = Path.Combine(outputFolder, GetThumbnailFileName(uwr));
             byte[] pngBytes = outputTexture.EncodeToPNG();
             File.WriteAllBytes(outputPath, pngBytes);
 
-            Destroy(outputTexture);
             return outputPath;
         }
         finally
         {
-            Destroy(readableTexture);
+            DestroyTexture(outputTexture);
         }
     }
 
-    private static Texture2D GetReadableTexture2D(Texture source)
+    private static Texture2D GetReadableTexture2D(Texture source, Rect sourceRect, int width, int height)
     {
-        if (source == null)
+        if (source == null || width < 1 || height < 1)
         {
             return null;
         }
 
+        int sourceX = Mathf.Clamp(Mathf.RoundToInt(sourceRect.x * source.width), 0, source.width - 1);
+        int sourceY = Mathf.Clamp(Mathf.RoundToInt(sourceRect.y * source.height), 0, source.height - 1);
+        int sourceWidth = Mathf.Clamp(Mathf.RoundToInt(sourceRect.width * source.width), 1, source.width - sourceX);
+        int sourceHeight = Mathf.Clamp(Mathf.RoundToInt(sourceRect.height * source.height), 1, source.height - sourceY);
+        Vector2 scale = new Vector2(
+            sourceWidth / (float)source.width,
+            sourceHeight / (float)source.height);
+        Vector2 offset = new Vector2(
+            sourceX / (float)source.width,
+            sourceY / (float)source.height);
+
         RenderTexture tmp = RenderTexture.GetTemporary(
-            source.width, source.height, 0,
+            width, height, 0,
             RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB);
-
-        Graphics.Blit(source, tmp);
         RenderTexture previous = RenderTexture.active;
-        RenderTexture.active = tmp;
+        Texture2D result = null;
+        try
+        {
+            Graphics.Blit(source, tmp, scale, offset);
+            RenderTexture.active = tmp;
 
-        Texture2D result = new Texture2D(source.width, source.height, TextureFormat.RGBA32, false);
-        result.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
-        result.Apply();
-
-        RenderTexture.active = previous;
-        RenderTexture.ReleaseTemporary(tmp);
-        return result;
+            result = new Texture2D(width, height, TextureFormat.RGBA32, false);
+            result.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+            result.Apply();
+            return result;
+        }
+        catch
+        {
+            if (result != null)
+            {
+                DestroyTexture(result);
+            }
+            throw;
+        }
+        finally
+        {
+            RenderTexture.active = previous;
+            RenderTexture.ReleaseTemporary(tmp);
+        }
     }
 
     private static float ApplyBrightnessContrast(float gray, float brightnessValue, float contrastValue)
@@ -596,6 +601,27 @@ public class IconCreator : MonoBehaviour
         return value;
     }
 
+    private Vector2Int GetIconDimensions()
+    {
+        return new Vector2Int(
+            Mathf.Max(1, Mathf.RoundToInt(IconDimensions.x)),
+            Mathf.Max(1, Mathf.RoundToInt(IconDimensions.y)));
+    }
+
+    private string GetThumbnailFileName(UMAWardrobeRecipe uwr)
+    {
+        string identifier = string.Empty;
+#if UNITY_EDITOR
+        string recipePath = AssetDatabase.GetAssetPath(uwr);
+        string recipeGuid = AssetDatabase.AssetPathToGUID(recipePath);
+        if (!string.IsNullOrEmpty(recipeGuid))
+        {
+            identifier = "_" + recipeGuid.Substring(0, 8);
+        }
+#endif
+        return SanitizePathSegment(uwr.name + identifier) + ".png";
+    }
+
     private bool CaptureRenderTextureToPng(Camera captureCamera, string outputPath)
     {
         if (captureCamera == null || captureCamera.targetTexture == null || string.IsNullOrEmpty(outputPath))
@@ -611,20 +637,61 @@ public class IconCreator : MonoBehaviour
 
         // captureCamera.Render();
 
+        Vector2Int iconDimensions = GetIconDimensions();
+        RenderTexture resizedTexture = RenderTexture.GetTemporary(
+            iconDimensions.x,
+            iconDimensions.y,
+            0,
+            RenderTextureFormat.ARGB32,
+            RenderTextureReadWrite.sRGB);
         RenderTexture previousActive = RenderTexture.active;
-        RenderTexture.active = renderTexture;
+        Texture2D capturedTexture = null;
+        try
+        {
+            Graphics.Blit(renderTexture, resizedTexture);
+            RenderTexture.active = resizedTexture;
 
-        Texture2D capturedTexture = new Texture2D(renderTexture.width, renderTexture.height, TextureFormat.RGBA32, false);
-        capturedTexture.ReadPixels(new Rect(0f, 0f, renderTexture.width, renderTexture.height), 0, 0);
-        capturedTexture.Apply();
+            capturedTexture = new Texture2D(
+                iconDimensions.x,
+                iconDimensions.y,
+                TextureFormat.RGBA32,
+                false);
+            capturedTexture.ReadPixels(
+                new Rect(0f, 0f, iconDimensions.x, iconDimensions.y),
+                0,
+                0);
+            capturedTexture.Apply();
 
-        byte[] pngBytes = capturedTexture.EncodeToPNG();
-        File.WriteAllBytes(outputPath, pngBytes);
-
-        RenderTexture.active = previousActive;
-        Destroy(capturedTexture); 
+            byte[] pngBytes = capturedTexture.EncodeToPNG();
+            File.WriteAllBytes(outputPath, pngBytes);
+        }
+        finally
+        {
+            RenderTexture.active = previousActive;
+            RenderTexture.ReleaseTemporary(resizedTexture);
+            if (capturedTexture != null)
+            {
+                DestroyTexture(capturedTexture);
+            }
+        }
 
         return true;
+    }
+
+    private static void DestroyTexture(Texture2D texture)
+    {
+#if UNITY_EDITOR
+        if (Application.isPlaying)
+        {
+            Destroy(texture);
+        }
+        else
+        {
+            DestroyImmediate(texture);
+        }
+#else
+        Destroy(texture);
+#endif
     }
 
 #if UNITY_EDITOR
@@ -649,6 +716,8 @@ public class IconCreator : MonoBehaviour
             textureImporter.spriteImportMode = SpriteImportMode.Single;
             textureImporter.mipmapEnabled = false;
             textureImporter.alphaIsTransparency = true;
+            textureImporter.filterMode = FilterMode.Bilinear;
+            textureImporter.textureCompression = TextureImporterCompression.Compressed;
             textureImporter.SaveAndReimport();
         }
 
@@ -708,6 +777,12 @@ public class IconCreator : MonoBehaviour
         return "Assets" + normalizedAbsolutePath.Substring(normalizedDataPath.Length);
     }
 #endif
+
+    private void OnValidate()
+    {
+        Vector2Int iconDimensions = GetIconDimensions();
+        IconDimensions = new Vector2(iconDimensions.x, iconDimensions.y);
+    }
 
     private bool ValidateCameraRegion(CameraRegions cameraRegions, out string validationMessage)
     {

--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -36,6 +36,9 @@ public class IconCreator : MonoBehaviour
     // Setup.
     public Vector2 IconDimensions = new Vector2(128, 128);
 
+    [Tooltip("Resize texture-derived thumbnails to Icon Dimensions instead of preserving the source crop resolution.")]
+    public bool ResizeTextureDerivedThumbnails = false;
+
     public float PreviewSize = 128.0f;
     public float scrollAreaHeight = 90.0f;
     public int currentCameraIndex = 0;
@@ -414,7 +417,7 @@ public class IconCreator : MonoBehaviour
         }
 
         Texture sourceTexture = textureList[0];
-        Vector2Int iconDimensions = GetIconDimensions();
+        Vector2Int iconDimensions = GetTextureThumbnailDimensions(sourceTexture, uwr.thumbnailRect);
         Texture2D outputTexture = GetReadableTexture2D(
             sourceTexture,
             uwr.thumbnailRect,
@@ -458,16 +461,13 @@ public class IconCreator : MonoBehaviour
             return null;
         }
 
-        int sourceX = Mathf.Clamp(Mathf.RoundToInt(sourceRect.x * source.width), 0, source.width - 1);
-        int sourceY = Mathf.Clamp(Mathf.RoundToInt(sourceRect.y * source.height), 0, source.height - 1);
-        int sourceWidth = Mathf.Clamp(Mathf.RoundToInt(sourceRect.width * source.width), 1, source.width - sourceX);
-        int sourceHeight = Mathf.Clamp(Mathf.RoundToInt(sourceRect.height * source.height), 1, source.height - sourceY);
+        RectInt sourcePixelRect = GetSourcePixelRect(source, sourceRect);
         Vector2 scale = new Vector2(
-            sourceWidth / (float)source.width,
-            sourceHeight / (float)source.height);
+            sourcePixelRect.width / (float)source.width,
+            sourcePixelRect.height / (float)source.height);
         Vector2 offset = new Vector2(
-            sourceX / (float)source.width,
-            sourceY / (float)source.height);
+            sourcePixelRect.x / (float)source.width,
+            sourcePixelRect.y / (float)source.height);
 
         RenderTexture tmp = RenderTexture.GetTemporary(
             width, height, 0,
@@ -497,6 +497,26 @@ public class IconCreator : MonoBehaviour
             RenderTexture.active = previous;
             RenderTexture.ReleaseTemporary(tmp);
         }
+    }
+
+    private Vector2Int GetTextureThumbnailDimensions(Texture source, Rect sourceRect)
+    {
+        if (ResizeTextureDerivedThumbnails)
+        {
+            return GetIconDimensions();
+        }
+
+        RectInt sourcePixelRect = GetSourcePixelRect(source, sourceRect);
+        return new Vector2Int(sourcePixelRect.width, sourcePixelRect.height);
+    }
+
+    private static RectInt GetSourcePixelRect(Texture source, Rect sourceRect)
+    {
+        int sourceX = Mathf.Clamp(Mathf.RoundToInt(sourceRect.x * source.width), 0, source.width - 1);
+        int sourceY = Mathf.Clamp(Mathf.RoundToInt(sourceRect.y * source.height), 0, source.height - 1);
+        int sourceWidth = Mathf.Clamp(Mathf.RoundToInt(sourceRect.width * source.width), 1, source.width - sourceX);
+        int sourceHeight = Mathf.Clamp(Mathf.RoundToInt(sourceRect.height * source.height), 1, source.height - sourceY);
+        return new RectInt(sourceX, sourceY, sourceWidth, sourceHeight);
     }
 
     private static float ApplyBrightnessContrast(float gray, float brightnessValue, float contrastValue)
@@ -629,27 +649,21 @@ public class IconCreator : MonoBehaviour
             return false;
         }
 
-        RenderTexture renderTexture = captureCamera.targetTexture;
-        if (!renderTexture.IsCreated())
-        {
-            renderTexture.Create();
-        }
-
-        // captureCamera.Render();
-
+        RenderTexture originalTarget = captureCamera.targetTexture;
         Vector2Int iconDimensions = GetIconDimensions();
-        RenderTexture resizedTexture = RenderTexture.GetTemporary(
+        RenderTexture captureTexture = RenderTexture.GetTemporary(
             iconDimensions.x,
             iconDimensions.y,
-            0,
+            originalTarget.depth,
             RenderTextureFormat.ARGB32,
             RenderTextureReadWrite.sRGB);
         RenderTexture previousActive = RenderTexture.active;
         Texture2D capturedTexture = null;
         try
         {
-            Graphics.Blit(renderTexture, resizedTexture);
-            RenderTexture.active = resizedTexture;
+            captureCamera.targetTexture = captureTexture;
+            captureCamera.Render();
+            RenderTexture.active = captureTexture;
 
             capturedTexture = new Texture2D(
                 iconDimensions.x,
@@ -667,8 +681,9 @@ public class IconCreator : MonoBehaviour
         }
         finally
         {
+            captureCamera.targetTexture = originalTarget;
             RenderTexture.active = previousActive;
-            RenderTexture.ReleaseTemporary(resizedTexture);
+            RenderTexture.ReleaseTemporary(captureTexture);
             if (capturedTexture != null)
             {
                 DestroyTexture(capturedTexture);

--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -36,6 +36,10 @@ public class IconCreator : MonoBehaviour
     // Setup.
     public Vector2 IconDimensions = new Vector2(128, 128);
 
+    [Range(1, 4)]
+    [Tooltip("Render camera thumbnails at a higher temporary resolution before downsampling. 2 is recommended.")]
+    public int CaptureSupersampling = 2;
+
     [Tooltip("Resize texture-derived thumbnails to Icon Dimensions instead of preserving the source crop resolution.")]
     public bool ResizeTextureDerivedThumbnails = false;
 
@@ -732,19 +736,42 @@ public class IconCreator : MonoBehaviour
 
         RenderTexture originalTarget = captureCamera.targetTexture;
         Vector2Int iconDimensions = GetIconDimensions();
+        int maxSupersampling = Mathf.Max(
+            1,
+            SystemInfo.maxTextureSize / Mathf.Max(iconDimensions.x, iconDimensions.y));
+        int supersampling = Mathf.Min(GetCaptureSupersampling(), maxSupersampling);
+        Vector2Int captureDimensions = new Vector2Int(
+            iconDimensions.x * supersampling,
+            iconDimensions.y * supersampling);
         RenderTexture captureTexture = RenderTexture.GetTemporary(
-            iconDimensions.x,
-            iconDimensions.y,
+            captureDimensions.x,
+            captureDimensions.y,
             originalTarget.depth,
             RenderTextureFormat.ARGB32,
             RenderTextureReadWrite.sRGB);
+        captureTexture.filterMode = FilterMode.Bilinear;
         RenderTexture previousActive = RenderTexture.active;
+        RenderTexture downsampledTexture = null;
         Texture2D capturedTexture = null;
         try
         {
             captureCamera.targetTexture = captureTexture;
             captureCamera.Render();
-            RenderTexture.active = captureTexture;
+
+            RenderTexture readTexture = captureTexture;
+            if (supersampling > 1)
+            {
+                downsampledTexture = RenderTexture.GetTemporary(
+                    iconDimensions.x,
+                    iconDimensions.y,
+                    0,
+                    RenderTextureFormat.ARGB32,
+                    RenderTextureReadWrite.sRGB);
+                downsampledTexture.filterMode = FilterMode.Bilinear;
+                Graphics.Blit(captureTexture, downsampledTexture);
+                readTexture = downsampledTexture;
+            }
+            RenderTexture.active = readTexture;
 
             capturedTexture = new Texture2D(
                 iconDimensions.x,
@@ -764,6 +791,10 @@ public class IconCreator : MonoBehaviour
         {
             captureCamera.targetTexture = originalTarget;
             RenderTexture.active = previousActive;
+            if (downsampledTexture != null)
+            {
+                RenderTexture.ReleaseTemporary(downsampledTexture);
+            }
             RenderTexture.ReleaseTemporary(captureTexture);
             if (capturedTexture != null)
             {
@@ -788,6 +819,11 @@ public class IconCreator : MonoBehaviour
 #else
         Destroy(texture);
 #endif
+    }
+
+    private int GetCaptureSupersampling()
+    {
+        return Mathf.Clamp(CaptureSupersampling, 1, 4);
     }
 
 #if UNITY_EDITOR
@@ -878,6 +914,7 @@ public class IconCreator : MonoBehaviour
     {
         Vector2Int iconDimensions = GetIconDimensions();
         IconDimensions = new Vector2(iconDimensions.x, iconDimensions.y);
+        CaptureSupersampling = GetCaptureSupersampling();
     }
 
     private bool ValidateCameraRegion(CameraRegions cameraRegions, out string validationMessage)

--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -343,8 +343,9 @@ public class IconCreator : MonoBehaviour
                         continue;
                     }
 
-                    string outputFolder = GetOutputFolder(region, avatar.activeRace.racedata.raceName);
-                    string outputPath = Path.Combine(outputFolder, GetThumbnailFileName(uwr));
+                    string captureRaceName = avatar.activeRace.racedata.raceName;
+                    string outputFolder = GetOutputFolder(region, captureRaceName);
+                    string outputPath = GetThumbnailOutputPath(uwr, captureRaceName, outputFolder);
                     if (!CaptureRenderTextureToPng(cameraRegions.camera, outputPath))
                     {
                         currentStatus = $"Failed to capture icon for recipe: {uwr.name}";
@@ -442,7 +443,7 @@ public class IconCreator : MonoBehaviour
             outputTexture.Apply();
 
             string outputFolder = GetOutputFolder(region, raceName);
-            string outputPath = Path.Combine(outputFolder, GetThumbnailFileName(uwr));
+            string outputPath = GetThumbnailOutputPath(uwr, raceName, outputFolder);
             byte[] pngBytes = outputTexture.EncodeToPNG();
             File.WriteAllBytes(outputPath, pngBytes);
 
@@ -628,7 +629,23 @@ public class IconCreator : MonoBehaviour
             Mathf.Max(1, Mathf.RoundToInt(IconDimensions.y)));
     }
 
-    private string GetThumbnailFileName(UMAWardrobeRecipe uwr)
+    private string GetThumbnailOutputPath(
+        UMAWardrobeRecipe uwr,
+        string raceName,
+        string outputFolder)
+    {
+#if UNITY_EDITOR
+        string existingAssetPath = GetExistingThumbnailAssetPath(uwr, raceName);
+        string existingAbsolutePath = GetAbsoluteAssetPath(existingAssetPath);
+        if (IsFileInFolder(existingAbsolutePath, outputFolder))
+        {
+            return existingAbsolutePath;
+        }
+#endif
+        return Path.Combine(outputFolder, GetNewThumbnailFileName(uwr));
+    }
+
+    private string GetNewThumbnailFileName(UMAWardrobeRecipe uwr)
     {
         string identifier = string.Empty;
 #if UNITY_EDITOR
@@ -641,6 +658,70 @@ public class IconCreator : MonoBehaviour
 #endif
         return SanitizePathSegment(uwr.name + identifier) + ".png";
     }
+
+#if UNITY_EDITOR
+    private static string GetExistingThumbnailAssetPath(UMAWardrobeRecipe uwr, string raceName)
+    {
+        if (uwr == null || uwr.wardrobeRecipeThumbs == null)
+        {
+            return null;
+        }
+
+        for (int i = 0; i < uwr.wardrobeRecipeThumbs.Count; i++)
+        {
+            WardrobeRecipeThumb thumbnail = uwr.wardrobeRecipeThumbs[i];
+            if (thumbnail == null || thumbnail.race != raceName)
+            {
+                continue;
+            }
+
+            string spritePath = AssetDatabase.GetAssetPath(thumbnail.thumb);
+            if (!string.IsNullOrEmpty(spritePath))
+            {
+                return spritePath;
+            }
+            if (!string.IsNullOrEmpty(thumbnail.filename))
+            {
+                return thumbnail.filename;
+            }
+        }
+        return null;
+    }
+
+    private static string GetAbsoluteAssetPath(string assetPath)
+    {
+        if (string.IsNullOrWhiteSpace(assetPath))
+        {
+            return null;
+        }
+
+        string normalizedPath = assetPath.Replace('\\', '/');
+        if (!normalizedPath.Equals("Assets", StringComparison.OrdinalIgnoreCase) &&
+            !normalizedPath.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        string relativePath = normalizedPath.Length == "Assets".Length
+            ? string.Empty
+            : normalizedPath.Substring("Assets/".Length);
+        return Path.GetFullPath(Path.Combine(Application.dataPath, relativePath));
+    }
+
+    private static bool IsFileInFolder(string filePath, string folderPath)
+    {
+        if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(folderPath) || !File.Exists(filePath))
+        {
+            return false;
+        }
+
+        string fileDirectory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+        string expectedDirectory = Path.GetFullPath(folderPath)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return fileDirectory != null &&
+            fileDirectory.Equals(expectedDirectory, StringComparison.OrdinalIgnoreCase);
+    }
+#endif
 
     private bool CaptureRenderTextureToPng(Camera captureCamera, string outputPath)
     {

--- a/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
+++ b/UMAProject/Assets/UMA/Core/DynamicCharacterSystem/Scripts/IconCreator.cs
@@ -54,6 +54,7 @@ public class IconCreator : MonoBehaviour
     private Texture2D flatHover = null;
     private Texture2D flatActive = null;
     private string currentStatus = "";
+    private bool isRendering = false;
     [Range(-1.0f, 1.0f)]
     public float brightness = 0.0f;
     [Range(-1.0f, 1.0f)]
@@ -228,7 +229,7 @@ public class IconCreator : MonoBehaviour
         GUILayout.Label("Region to Render", GUILayout.Width(110f));
 
         bool hasRaceRegions = raceRegions != null && raceRegions.Count > 0;
-        GUI.enabled = hasRaceRegions;
+        GUI.enabled = hasRaceRegions && !isRendering;
 
         string selectedRegionLabel = hasRaceRegions ? raceRegions[selectedRegionIndex] : "No regions available";
         if (GUILayout.Button(selectedRegionLabel, GUILayout.Width(220f)))
@@ -279,105 +280,483 @@ public class IconCreator : MonoBehaviour
     }
 
 
+    private sealed class ThumbnailGenerationItem
+    {
+        public string OutputPath;
+        public UMAWardrobeRecipe SourceRecipe;
+        public UMAWardrobeRecipe RenderRecipe;
+    }
+
+#if UNITY_EDITOR
+    private sealed class ThumbnailReferenceSnapshot
+    {
+        public WardrobeRecipeThumb Thumbnail;
+        public string AssetPath;
+    }
+
+    private sealed class ThumbnailGenerationSession : IDisposable
+    {
+        private readonly List<ThumbnailGenerationItem> items;
+        private readonly List<ThumbnailReferenceSnapshot> references;
+        private readonly List<string> atlasAssetPaths;
+        private bool recipesChanged;
+
+        public ThumbnailGenerationSession(
+            List<ThumbnailGenerationItem> items,
+            List<ThumbnailReferenceSnapshot> references,
+            List<string> atlasAssetPaths)
+        {
+            this.items = items;
+            this.references = references;
+            this.atlasAssetPaths = atlasAssetPaths;
+        }
+
+        public void MarkRecipeChanged()
+        {
+            recipesChanged = true;
+        }
+
+        public void Dispose()
+        {
+            for (int i = 0; i < atlasAssetPaths.Count; i++)
+            {
+                AssetDatabase.LoadAssetAtPath<UnityEngine.U2D.SpriteAtlas>(atlasAssetPaths[i]);
+            }
+
+            bool referencesRestored = true;
+            for (int i = 0; i < references.Count; i++)
+            {
+                ThumbnailReferenceSnapshot reference = references[i];
+                try
+                {
+                    if (reference.Thumbnail != null)
+                    {
+                        Sprite sprite = AssetDatabase.LoadAssetAtPath<Sprite>(reference.AssetPath);
+                        reference.Thumbnail.thumb = sprite;
+                        referencesRestored &= sprite != null;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    referencesRestored = false;
+                    Debug.LogException(exception);
+                }
+            }
+
+            for (int i = 0; i < items.Count; i++)
+            {
+                UMAWardrobeRecipe renderRecipe = items[i].RenderRecipe;
+                if (renderRecipe == null || renderRecipe == items[i].SourceRecipe)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    DestroyDetachedRecipe(renderRecipe);
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogException(exception);
+                }
+            }
+
+            if (recipesChanged && referencesRestored)
+            {
+                try
+                {
+                    AssetDatabase.SaveAssets();
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogException(exception);
+                }
+            }
+            else if (recipesChanged)
+            {
+                Debug.LogError(
+                    "IconCreator: Thumbnail references could not be restored. " +
+                    "Recipe changes were not saved to protect the original assets.");
+            }
+        }
+    }
+#else
+    private sealed class ThumbnailGenerationSession : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+#endif
+
     private IEnumerator RenderRegion(string region)
     {
-        var ugb = UMAAssetIndexer.Instance.Generator;
-
+        if (isRendering)
+        {
+            yield break;
+        }
         if (string.IsNullOrEmpty(region))
         {
             currentStatus = "No region selected for rendering.";
             yield break;
         }
-        currentStatus = $"Rendering region: {region}";
-        var recipes = avatar.AvailableRecipes;
-        if (recipes != null && recipes.TryGetValue(region, out List<UMATextRecipe> regionRecipes))
+
+        isRendering = true;
+        ThumbnailGenerationSession session = null;
+        try
         {
-            foreach (var recipe in regionRecipes)
+            Dictionary<string, List<ThumbnailGenerationItem>> preparedRecipes =
+                PrepareThumbnailGeneration(new List<string> { region }, out session);
+#if UNITY_EDITOR
+            yield return Resources.UnloadUnusedAssets();
+            AssetDatabase.ReleaseCachedFileHandles();
+#endif
+            if (preparedRecipes.TryGetValue(region, out List<ThumbnailGenerationItem> regionRecipes))
             {
-                var uwr = recipe as UMAWardrobeRecipe;
-                if (uwr != null)
+                IEnumerator renderer = RenderPreparedRegion(
+                    region,
+                    regionRecipes,
+                    session);
+                while (renderer.MoveNext())
                 {
-                    // If thumbnailFromTexture is enabled, generate thumbnail from recipe texture instead of camera capture
-                    if (uwr.thumbnailFromTexture)
-                    {
-                        string raceName = avatar.activeRace.racedata.raceName;
-                        string textureOutputPath = GenerateThumbnailFromRecipeTexture(uwr, region, raceName);
-                        if (!string.IsNullOrEmpty(textureOutputPath))
-                        {
-#if UNITY_EDITOR
-                            UpdateWardrobeRecipeThumb(uwr, textureOutputPath);
-#endif
-                            currentStatus = $"Generated texture thumbnail for recipe: {uwr.name}";
-                        }
-                        else
-                        {
-                            currentStatus = $"Failed to generate texture thumbnail for recipe: {uwr.name} (no texture found in recipe)";
-                        }
-                        continue;
-                    }
-
-                    currentStatus = $"Rendering recipe: {uwr.name} for region: {region}";
-                    avatar.ClearWearableItems(region);
-                    avatar.SetWearableItem(uwr);
-                    avatar.BuildCharacter();
-                    ugb.GenerateSingleUMA(avatar, true);
-                    // Wait until the avatar has finished updating before attempting to capture the icon.
-
-                    // wait a frame to ensure character is rendered with the new wardrobe item before capturing the icon.
-                    yield return null;
-                    // ensure wearable items are cleared after rendering the icon so that the avatar is back to a clean state for the next recipe to be rendered.
-                    // and that the last one doesn't affect the next region to be rendered.
-                    avatar.ClearWearableItems(region);
-                    CameraRegions cameraRegions = GetCameraRegionsForRegion(region);
-                    if (cameraRegions == null)
-                    {
-                        currentStatus = $"No camera configured for region: {region}";
-                        continue;
-                    }
-
-                    if (cameraRegions.camera == null)
-                    {
-                        currentStatus = $"Camera is missing for region: {region}";
-                        continue;
-                    }
-
-                    if (cameraRegions.camera.targetTexture == null)
-                    {
-                        currentStatus = $"Camera target texture is missing for region: {region}";
-                        continue;
-                    }
-
-                    string captureRaceName = avatar.activeRace.racedata.raceName;
-                    string outputFolder = GetOutputFolder(region, captureRaceName);
-                    string outputPath = GetThumbnailOutputPath(uwr, captureRaceName, outputFolder);
-                    if (!CaptureRenderTextureToPng(cameraRegions.camera, outputPath))
-                    {
-                        currentStatus = $"Failed to capture icon for recipe: {uwr.name}";
-                        continue;
-                    }
-
-#if UNITY_EDITOR
-                    UpdateWardrobeRecipeThumb(uwr, outputPath);
-#endif
-                    // todo: update the manual progress bar here to show progress for each region and recipe being rendered.
+                    yield return renderer.Current;
                 }
             }
+        }
+        finally
+        {
+            session?.Dispose();
+            isRendering = false;
+        }
+    }
+
+    private IEnumerator RenderAllRegions()
+    {
+        if (isRendering)
+        {
+            yield break;
+        }
+
+        Dictionary<string, List<UMATextRecipe>> availableRecipes = avatar.AvailableRecipes;
+        if (availableRecipes == null)
+        {
+            yield break;
+        }
+
+        isRendering = true;
+        ThumbnailGenerationSession session = null;
+        try
+        {
+            List<string> regions = new List<string>(availableRecipes.Keys);
+            Dictionary<string, List<ThumbnailGenerationItem>> preparedRecipes =
+                PrepareThumbnailGeneration(regions, out session);
+#if UNITY_EDITOR
+            yield return Resources.UnloadUnusedAssets();
+            AssetDatabase.ReleaseCachedFileHandles();
+#endif
+            for (int i = 0; i < regions.Count; i++)
+            {
+                string region = regions[i];
+                if (preparedRecipes.TryGetValue(region, out List<ThumbnailGenerationItem> regionRecipes))
+                {
+                    IEnumerator renderer = RenderPreparedRegion(
+                        region,
+                        regionRecipes,
+                        session);
+                    while (renderer.MoveNext())
+                    {
+                        yield return renderer.Current;
+                    }
+                }
+            }
+        }
+        finally
+        {
+            session?.Dispose();
+            isRendering = false;
+        }
+    }
+
+    private Dictionary<string, List<ThumbnailGenerationItem>> PrepareThumbnailGeneration(
+        List<string> regions,
+        out ThumbnailGenerationSession session)
+    {
+        session = null;
+        var result = new Dictionary<string, List<ThumbnailGenerationItem>>();
+        Dictionary<string, List<UMATextRecipe>> availableRecipes = avatar.AvailableRecipes;
+        if (availableRecipes == null || avatar.activeRace.racedata == null)
+        {
+            return result;
+        }
+
+        string raceName = avatar.activeRace.racedata.raceName;
+        var allItems = new List<ThumbnailGenerationItem>();
+        for (int regionIndex = 0; regionIndex < regions.Count; regionIndex++)
+        {
+            string region = regions[regionIndex];
+            var preparedRegion = new List<ThumbnailGenerationItem>();
+            result.Add(region, preparedRegion);
+            if (!availableRecipes.TryGetValue(region, out List<UMATextRecipe> regionRecipes))
+            {
+                continue;
+            }
+
+            string outputFolder = GetOutputFolder(region, raceName);
+            for (int recipeIndex = 0; recipeIndex < regionRecipes.Count; recipeIndex++)
+            {
+                UMAWardrobeRecipe sourceRecipe = regionRecipes[recipeIndex] as UMAWardrobeRecipe;
+                if (sourceRecipe == null)
+                {
+                    continue;
+                }
+
+                var item = new ThumbnailGenerationItem
+                {
+                    OutputPath = GetThumbnailOutputPath(sourceRecipe, raceName, outputFolder),
+                    SourceRecipe = sourceRecipe,
+                    RenderRecipe = sourceRecipe
+                };
+#if UNITY_EDITOR
+                item.RenderRecipe = CreateDetachedRecipe(sourceRecipe);
+#endif
+                preparedRegion.Add(item);
+                allItems.Add(item);
+            }
+        }
+
+#if UNITY_EDITOR
+        UMAWardrobeRecipe[] sourceRecipes = GetDistinctSourceRecipes(allItems);
+        if (sourceRecipes.Length > 0)
+        {
+            Undo.RecordObjects(sourceRecipes, "Update Wardrobe Recipe Thumbnails");
+        }
+        var references = new List<ThumbnailReferenceSnapshot>();
+        var atlasAssetPaths = new List<string>();
+        session = new ThumbnailGenerationSession(allItems, references, atlasAssetPaths);
+        ReleaseManagedThumbnailAtlases(atlasAssetPaths);
+        ReleaseThumbnailReferences(availableRecipes, allItems, references);
+#else
+        session = new ThumbnailGenerationSession();
+#endif
+        return result;
+    }
+
+#if UNITY_EDITOR
+    private static UMAWardrobeRecipe[] GetDistinctSourceRecipes(List<ThumbnailGenerationItem> items)
+    {
+        var recipes = new List<UMAWardrobeRecipe>();
+        var seen = new HashSet<UMAWardrobeRecipe>();
+        for (int i = 0; i < items.Count; i++)
+        {
+            UMAWardrobeRecipe recipe = items[i].SourceRecipe;
+            if (recipe != null && seen.Add(recipe))
+            {
+                recipes.Add(recipe);
+            }
+        }
+        return recipes.ToArray();
+    }
+
+    private void ReleaseThumbnailReferences(
+        Dictionary<string, List<UMATextRecipe>> availableRecipes,
+        List<ThumbnailGenerationItem> items,
+        List<ThumbnailReferenceSnapshot> references)
+    {
+        var outputAssetPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < items.Count; i++)
+        {
+            string assetPath = GetAssetRelativePath(items[i].OutputPath);
+            if (!string.IsNullOrEmpty(assetPath))
+            {
+                outputAssetPaths.Add(assetPath.Replace('\\', '/'));
+            }
+        }
+
+        var visitedRecipes = new HashSet<UMAWardrobeRecipe>();
+        foreach (KeyValuePair<string, List<UMATextRecipe>> pair in availableRecipes)
+        {
+            List<UMATextRecipe> recipes = pair.Value;
+            for (int recipeIndex = 0; recipeIndex < recipes.Count; recipeIndex++)
+            {
+                UMAWardrobeRecipe recipe = recipes[recipeIndex] as UMAWardrobeRecipe;
+                if (recipe == null || !visitedRecipes.Add(recipe) || recipe.wardrobeRecipeThumbs == null)
+                {
+                    continue;
+                }
+
+                for (int thumbnailIndex = 0; thumbnailIndex < recipe.wardrobeRecipeThumbs.Count; thumbnailIndex++)
+                {
+                    WardrobeRecipeThumb thumbnail = recipe.wardrobeRecipeThumbs[thumbnailIndex];
+                    if (thumbnail == null || thumbnail.thumb == null)
+                    {
+                        continue;
+                    }
+
+                    string assetPath = AssetDatabase.GetAssetPath(thumbnail.thumb).Replace('\\', '/');
+                    if (!outputAssetPaths.Contains(assetPath))
+                    {
+                        continue;
+                    }
+
+                    references.Add(new ThumbnailReferenceSnapshot
+                    {
+                        Thumbnail = thumbnail,
+                        AssetPath = assetPath
+                    });
+                    thumbnail.thumb = null;
+                }
+            }
+        }
+
+        foreach (string assetPath in outputAssetPaths)
+        {
+            UnloadThumbnailAsset(assetPath);
+        }
+        AssetDatabase.ReleaseCachedFileHandles();
+    }
+
+    private static UMAWardrobeRecipe CreateDetachedRecipe(UMAWardrobeRecipe sourceRecipe)
+    {
+        UMAWardrobeRecipe renderRecipe = Instantiate(sourceRecipe);
+        try
+        {
+            renderRecipe.name = sourceRecipe.name;
+            renderRecipe.hideFlags = HideFlags.HideAndDontSave;
+            renderRecipe.wardrobeRecipeThumbs = new List<WardrobeRecipeThumb>();
+            return renderRecipe;
+        }
+        catch
+        {
+            DestroyDetachedRecipe(renderRecipe);
+            throw;
+        }
+    }
+
+    private static void DestroyDetachedRecipe(UMAWardrobeRecipe recipe)
+    {
+        if (Application.isPlaying)
+        {
+            Destroy(recipe);
+        }
+        else
+        {
+            DestroyImmediate(recipe);
+        }
+    }
+
+    private static void UnloadThumbnailAsset(string assetPath)
+    {
+        Sprite sprite = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
+        if (sprite == null)
+        {
+            return;
+        }
+
+        Resources.UnloadAsset(sprite);
+    }
+
+    private void ReleaseManagedThumbnailAtlases(List<string> atlasAssetPaths)
+    {
+        string atlasFolder = GetManagedAtlasAssetFolder();
+        UnityEngine.U2D.SpriteAtlas[] loadedAtlases =
+            Resources.FindObjectsOfTypeAll<UnityEngine.U2D.SpriteAtlas>();
+        for (int i = 0; i < loadedAtlases.Length; i++)
+        {
+            UnityEngine.U2D.SpriteAtlas atlas = loadedAtlases[i];
+            string atlasPath = AssetDatabase.GetAssetPath(atlas).Replace('\\', '/');
+            if (!atlasPath.StartsWith(atlasFolder + "/", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            atlasAssetPaths.Add(atlasPath);
+            Resources.UnloadAsset(atlas);
+        }
+    }
+
+    private string GetManagedAtlasAssetFolder()
+    {
+        string normalizedRootFolder = NormalizeRootFolder(rootFolder).Replace('\\', '/').Trim('/');
+        return string.IsNullOrEmpty(normalizedRootFolder)
+            ? "Assets/SpriteAtlases"
+            : "Assets/" + normalizedRootFolder + "/SpriteAtlases";
+    }
+#endif
+
+    private IEnumerator RenderPreparedRegion(
+        string region,
+        List<ThumbnailGenerationItem> recipes,
+        ThumbnailGenerationSession session)
+    {
+        var ugb = UMAAssetIndexer.Instance.Generator;
+        currentStatus = $"Rendering region: {region}";
+        for (int i = 0; i < recipes.Count; i++)
+        {
+            ThumbnailGenerationItem item = recipes[i];
+            UMAWardrobeRecipe uwr = item.RenderRecipe;
+            if (uwr.thumbnailFromTexture)
+            {
+                string textureOutputPath = GenerateThumbnailFromRecipeTexture(
+                    uwr,
+                    item.OutputPath);
+                if (!string.IsNullOrEmpty(textureOutputPath))
+                {
+#if UNITY_EDITOR
+                    if (UpdateWardrobeRecipeThumb(item.SourceRecipe, textureOutputPath))
+                    {
+                        session.MarkRecipeChanged();
+                    }
+#endif
+                    currentStatus = $"Generated texture thumbnail for recipe: {uwr.name}";
+                }
+                else
+                {
+                    currentStatus = $"Failed to generate texture thumbnail for recipe: {uwr.name} (no texture found in recipe)";
+                }
+                continue;
+            }
+
+            currentStatus = $"Rendering recipe: {uwr.name} for region: {region}";
+            avatar.ClearWearableItems(region);
+            avatar.SetWearableItem(uwr);
+            avatar.BuildCharacter();
+            ugb.GenerateSingleUMA(avatar, true);
+            yield return null;
+            avatar.ClearWearableItems(region);
+
+            CameraRegions cameraRegions = GetCameraRegionsForRegion(region);
+            if (cameraRegions == null)
+            {
+                currentStatus = $"No camera configured for region: {region}";
+                continue;
+            }
+            if (cameraRegions.camera == null)
+            {
+                currentStatus = $"Camera is missing for region: {region}";
+                continue;
+            }
+            if (cameraRegions.camera.targetTexture == null)
+            {
+                currentStatus = $"Camera target texture is missing for region: {region}";
+                continue;
+            }
+            if (!CaptureRenderTextureToPng(cameraRegions.camera, item.OutputPath))
+            {
+                currentStatus = $"Failed to capture icon for recipe: {uwr.name}";
+                continue;
+            }
+
+#if UNITY_EDITOR
+            if (UpdateWardrobeRecipeThumb(item.SourceRecipe, item.OutputPath))
+            {
+                session.MarkRecipeChanged();
+            }
+#endif
         }
         currentStatus = $"Finished rendering region: {region}";
     }
 
-
-    private IEnumerator RenderAllRegions()
-    {
-        Dictionary<string, List<UMATextRecipe>> recipes = avatar.AvailableRecipes;
-        foreach(var kvp in recipes)
-        {
-            string region = kvp.Key;
-            yield return StartCoroutine(RenderRegion(region));
-        }
-    }
-
-    private string GenerateThumbnailFromRecipeTexture(UMAWardrobeRecipe uwr, string region, string raceName)
+    private string GenerateThumbnailFromRecipeTexture(UMAWardrobeRecipe uwr, string outputPath)
     {
         if (uwr == null)
         {
@@ -446,10 +825,8 @@ public class IconCreator : MonoBehaviour
             outputTexture.SetPixels(outputPixels);
             outputTexture.Apply();
 
-            string outputFolder = GetOutputFolder(region, raceName);
-            string outputPath = GetThumbnailOutputPath(uwr, raceName, outputFolder);
             byte[] pngBytes = outputTexture.EncodeToPNG();
-            File.WriteAllBytes(outputPath, pngBytes);
+            WriteThumbnailFile(outputPath, pngBytes);
 
             return outputPath;
         }
@@ -785,7 +1162,7 @@ public class IconCreator : MonoBehaviour
             capturedTexture.Apply();
 
             byte[] pngBytes = capturedTexture.EncodeToPNG();
-            File.WriteAllBytes(outputPath, pngBytes);
+            WriteThumbnailFile(outputPath, pngBytes);
         }
         finally
         {
@@ -803,6 +1180,59 @@ public class IconCreator : MonoBehaviour
         }
 
         return true;
+    }
+
+    private static void WriteThumbnailFile(string outputPath, byte[] pngBytes)
+    {
+        const int maxWriteAttempts = 8;
+        const int retryDelayMilliseconds = 25;
+#if UNITY_EDITOR
+        AssetDatabase.ReleaseCachedFileHandles();
+#endif
+        string temporaryPath = outputPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            for (int attempt = 1; attempt <= maxWriteAttempts; attempt++)
+            {
+                try
+                {
+                    if (!File.Exists(temporaryPath))
+                    {
+                        File.WriteAllBytes(temporaryPath, pngBytes);
+                    }
+                    if (File.Exists(outputPath))
+                    {
+                        File.Replace(temporaryPath, outputPath, null);
+                    }
+                    else
+                    {
+                        File.Move(temporaryPath, outputPath);
+                    }
+                    return;
+                }
+                catch (IOException exception)
+                {
+                    if (attempt == maxWriteAttempts)
+                    {
+                        throw new IOException(
+                            "Unable to replace thumbnail '" + outputPath +
+                            "' after " + maxWriteAttempts + " attempts.",
+                            exception);
+                    }
+#if UNITY_EDITOR
+                    AssetDatabase.ReleaseCachedFileHandles();
+#endif
+                    System.Threading.Thread.Sleep(retryDelayMilliseconds * attempt);
+                }
+            }
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
     }
 
     private static void DestroyTexture(Texture2D texture)
@@ -827,20 +1257,22 @@ public class IconCreator : MonoBehaviour
     }
 
 #if UNITY_EDITOR
-    private void UpdateWardrobeRecipeThumb(UMAWardrobeRecipe uwr, string outputPath)
+    private bool UpdateWardrobeRecipeThumb(UMAWardrobeRecipe uwr, string outputPath)
     {
         if (uwr == null || avatar == null || avatar.activeRace.data == null || string.IsNullOrEmpty(outputPath))
         {
-            return;
+            return false;
         }
 
         string relativePath = GetAssetRelativePath(outputPath);
         if (string.IsNullOrEmpty(relativePath))
         {
-            return;
+            return false;
         }
 
-        AssetDatabase.ImportAsset(relativePath, ImportAssetOptions.ForceUpdate);
+        AssetDatabase.ImportAsset(
+            relativePath,
+            ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
         TextureImporter textureImporter = AssetImporter.GetAtPath(relativePath) as TextureImporter;
         if (textureImporter != null)
         {
@@ -856,11 +1288,10 @@ public class IconCreator : MonoBehaviour
         Sprite sprite = AssetDatabase.LoadAssetAtPath<Sprite>(relativePath);
         if (sprite == null)
         {
-            return;
+            return false;
         }
 
         string raceName = avatar.activeRace.data.raceName;
-        Undo.RecordObject(uwr, "Update Wardrobe Recipe Thumbnail");
 
         if (uwr.wardrobeRecipeThumbs == null)
         {
@@ -888,8 +1319,7 @@ public class IconCreator : MonoBehaviour
         wardrobeRecipeThumb.thumb = sprite;
 
         EditorUtility.SetDirty(uwr);
-        AssetDatabase.SaveAssets();
-        AssetDatabase.Refresh();
+        return true;
     }
 
     private string GetAssetRelativePath(string absolutePath)

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorEditor.cs
@@ -77,6 +77,11 @@ public class IconCreatorEditor : Editor
             {
                 message += "\n\nCleared packables from " + result.ClearedAtlasCount + " obsolete atlases.";
             }
+            if (result.RemovedAtlasCount > 0)
+            {
+                message += "\n\nRemoved " + result.RemovedAtlasCount +
+                    " generated atlases from the inactive Sprite Atlas version.";
+            }
             if (result.WarningCount > 0)
             {
                 message += "\n\n" + result.WarningCount + " conflicts were logged as warnings.";

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorEditor.cs
@@ -39,8 +39,16 @@ public class IconCreatorEditor : Editor
     {
         EditorGUILayout.LabelField("Thumbnail Sprite Atlases", EditorStyles.boldLabel);
         EditorGUILayout.HelpBox(
-            "Rebuilds atlases from the Sprites referenced by wardrobe recipes, grouped by race and wardrobe region.",
+            "Optional. Rebuilds Sprite Atlas V2 assets from the Sprites referenced by wardrobe recipes, " +
+            "grouped by race and wardrobe region.",
             MessageType.Info);
+
+        if (!IconCreatorSpriteAtlasUtility.IsSpriteAtlasV2Enabled())
+        {
+            EditorGUILayout.HelpBox(
+                IconCreatorSpriteAtlasUtility.SpriteAtlasV2RequiredMessage,
+                MessageType.Info);
+        }
 
         string atlasFolder;
         try
@@ -66,6 +74,18 @@ public class IconCreatorEditor : Editor
 
     private static void RebuildThumbnailAtlases(string rootFolder)
     {
+        if (!IconCreatorSpriteAtlasUtility.IsSpriteAtlasV2Enabled())
+        {
+            Debug.LogError(
+                "[IconCreator] " +
+                IconCreatorSpriteAtlasUtility.SpriteAtlasV2RequiredMessage);
+            EditorUtility.DisplayDialog(
+                "Sprite Atlas V2 Required",
+                IconCreatorSpriteAtlasUtility.SpriteAtlasV2RequiredMessage,
+                "OK");
+            return;
+        }
+
         try
         {
             IconCreatorSpriteAtlasUtility.RebuildResult result =
@@ -76,11 +96,6 @@ public class IconCreatorEditor : Editor
             if (result.ClearedAtlasCount > 0)
             {
                 message += "\n\nCleared packables from " + result.ClearedAtlasCount + " obsolete atlases.";
-            }
-            if (result.RemovedAtlasCount > 0)
-            {
-                message += "\n\nRemoved " + result.RemovedAtlasCount +
-                    " generated atlases from the inactive Sprite Atlas version.";
             }
             if (result.WarningCount > 0)
             {

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorEditor.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorEditor.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -28,8 +29,66 @@ public class IconCreatorEditor : Editor
         DrawCameraRegions();
         EditorGUILayout.Space();
         DrawPropertiesExcluding(serializedObject, "m_Script", "rootFolder", "regionToCameraList");
+        EditorGUILayout.Space();
+        DrawSpriteAtlasControls();
 
         serializedObject.ApplyModifiedProperties();
+    }
+
+    private void DrawSpriteAtlasControls()
+    {
+        EditorGUILayout.LabelField("Thumbnail Sprite Atlases", EditorStyles.boldLabel);
+        EditorGUILayout.HelpBox(
+            "Rebuilds atlases from the Sprites referenced by wardrobe recipes, grouped by race and wardrobe region.",
+            MessageType.Info);
+
+        string atlasFolder;
+        try
+        {
+            atlasFolder = IconCreatorSpriteAtlasUtility.GetAtlasFolder(rootFolderProperty.stringValue);
+        }
+        catch (ArgumentException exception)
+        {
+            EditorGUILayout.HelpBox(exception.Message, MessageType.Error);
+            return;
+        }
+        EditorGUILayout.LabelField("Output Folder", atlasFolder);
+
+        using (new EditorGUI.DisabledScope(EditorApplication.isPlayingOrWillChangePlaymode))
+        {
+            if (GUILayout.Button("Rebuild Thumbnail Atlases"))
+            {
+                serializedObject.ApplyModifiedProperties();
+                RebuildThumbnailAtlases(rootFolderProperty.stringValue);
+            }
+        }
+    }
+
+    private static void RebuildThumbnailAtlases(string rootFolder)
+    {
+        try
+        {
+            IconCreatorSpriteAtlasUtility.RebuildResult result =
+                IconCreatorSpriteAtlasUtility.Rebuild(rootFolder);
+            string message =
+                "Rebuilt " + result.AtlasCount + " atlases from " + result.SpriteCount +
+                " referenced Sprites across " + result.RecipeCount + " wardrobe recipes.";
+            if (result.ClearedAtlasCount > 0)
+            {
+                message += "\n\nCleared packables from " + result.ClearedAtlasCount + " obsolete atlases.";
+            }
+            if (result.WarningCount > 0)
+            {
+                message += "\n\n" + result.WarningCount + " conflicts were logged as warnings.";
+            }
+            message += "\n\nOutput: " + result.OutputFolder;
+            EditorUtility.DisplayDialog("Thumbnail Sprite Atlases", message, "OK");
+        }
+        catch (Exception exception)
+        {
+            Debug.LogException(exception);
+            EditorUtility.DisplayDialog("Thumbnail Sprite Atlases", exception.Message, "OK");
+        }
     }
 
     private void DrawRootFolder()

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
@@ -13,6 +13,10 @@ public static class IconCreatorSpriteAtlasUtility
 {
     private const string AtlasFolderName = "SpriteAtlases";
     private const string AtlasNamePrefix = "UMAIcons_";
+    public const string SpriteAtlasV2RequiredMessage =
+        "Thumbnail Sprite Atlas generation is optional, but requires Sprite Atlas V2 in the Editor. " +
+        "Open Edit > Project Settings > Editor and set Sprite Atlas > Mode to " +
+        "'Sprite Atlas V2 - Enabled', then run the tool again.";
 
     public sealed class RebuildResult
     {
@@ -21,7 +25,6 @@ public static class IconCreatorSpriteAtlasUtility
         public int SpriteCount { get; }
         public int AtlasCount { get; }
         public int ClearedAtlasCount { get; }
-        public int RemovedAtlasCount { get; }
         public int WarningCount { get; }
 
         public RebuildResult(
@@ -30,7 +33,6 @@ public static class IconCreatorSpriteAtlasUtility
             int spriteCount,
             int atlasCount,
             int clearedAtlasCount,
-            int removedAtlasCount,
             int warningCount)
         {
             OutputFolder = outputFolder;
@@ -38,7 +40,6 @@ public static class IconCreatorSpriteAtlasUtility
             SpriteCount = spriteCount;
             AtlasCount = atlasCount;
             ClearedAtlasCount = clearedAtlasCount;
-            RemovedAtlasCount = removedAtlasCount;
             WarningCount = warningCount;
         }
     }
@@ -50,13 +51,18 @@ public static class IconCreatorSpriteAtlasUtility
 
     public static RebuildResult Rebuild(string rootFolder)
     {
-        string atlasFolder = GetAtlasFolder(rootFolder);
+        EnsureSpriteAtlasV2Enabled(EditorSettings.spritePackerMode);
+
+        string assetRootFolder = GetAssetRootFolder(rootFolder);
+        string atlasFolder = assetRootFolder + "/" + AtlasFolderName;
         EnsureAssetFolder(atlasFolder);
 
         var warnings = new List<string>();
         var sourceAssignments = new Dictionary<string, AtlasGroupKey>(StringComparer.OrdinalIgnoreCase);
         int recipeCount;
         Dictionary<AtlasGroupKey, HashSet<Sprite>> groups = CollectGroups(
+            assetRootFolder,
+            atlasFolder,
             sourceAssignments,
             warnings,
             out recipeCount);
@@ -67,7 +73,6 @@ public static class IconCreatorSpriteAtlasUtility
         groupKeys.Sort(CompareGroupKeys);
         var rebuiltPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var usedAtlasPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        bool useSpriteAtlasV2 = IsSpriteAtlasV2Enabled(EditorSettings.spritePackerMode);
         int spriteCount = 0;
 
         for (int i = 0; i < groupKeys.Count; i++)
@@ -77,18 +82,15 @@ public static class IconCreatorSpriteAtlasUtility
             string atlasPath = GetUniqueAtlasPath(
                 atlasFolder,
                 groupKey,
-                usedAtlasPaths,
-                useSpriteAtlasV2);
-            RebuildAtlas(atlasPath, sprites, useSpriteAtlasV2);
+                usedAtlasPaths);
+            RebuildAtlas(atlasPath, sprites);
             rebuiltPaths.Add(atlasPath);
             spriteCount += sprites.Count;
         }
 
         int clearedAtlasCount = ClearObsoleteAtlasPackables(
             atlasFolder,
-            rebuiltPaths,
-            useSpriteAtlasV2);
-        int removedAtlasCount = RemoveInactiveAtlasAssets(atlasFolder, useSpriteAtlasV2);
+            rebuiltPaths);
         AssetDatabase.SaveAssets();
 
         for (int i = 0; i < warnings.Count; i++)
@@ -102,11 +104,12 @@ public static class IconCreatorSpriteAtlasUtility
             spriteCount,
             groupKeys.Count,
             clearedAtlasCount,
-            removedAtlasCount,
             warnings.Count);
     }
 
     private static Dictionary<AtlasGroupKey, HashSet<Sprite>> CollectGroups(
+        string assetRootFolder,
+        string atlasFolder,
         Dictionary<string, AtlasGroupKey> sourceAssignments,
         List<string> warnings,
         out int recipeCount)
@@ -138,8 +141,8 @@ public static class IconCreatorSpriteAtlasUtility
                     continue;
                 }
 
-                string sourcePath = AssetDatabase.GetAssetPath(thumbnail.thumb);
-                if (string.IsNullOrEmpty(sourcePath))
+                string sourcePath = AssetDatabase.GetAssetPath(thumbnail.thumb).Replace('\\', '/');
+                if (!IsThumbnailSourcePath(sourcePath, assetRootFolder, atlasFolder))
                 {
                     continue;
                 }
@@ -175,6 +178,29 @@ public static class IconCreatorSpriteAtlasUtility
         return groups;
     }
 
+    private static bool IsThumbnailSourcePath(
+        string sourcePath,
+        string assetRootFolder,
+        string atlasFolder)
+    {
+        return IsAssetInFolder(sourcePath, assetRootFolder) &&
+            !IsAssetInFolder(sourcePath, atlasFolder);
+    }
+
+    private static bool IsAssetInFolder(string assetPath, string assetFolder)
+    {
+        if (string.IsNullOrEmpty(assetPath) || string.IsNullOrEmpty(assetFolder))
+        {
+            return false;
+        }
+
+        string normalizedPath = assetPath.Replace('\\', '/');
+        string normalizedFolder = assetFolder.Replace('\\', '/').TrimEnd('/');
+        return normalizedPath.StartsWith(
+            normalizedFolder + "/",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     private static void WarnAboutExternalAtlasAssignments(
         Dictionary<string, AtlasGroupKey> sourceAssignments,
         string atlasFolder,
@@ -185,7 +211,7 @@ public static class IconCreatorSpriteAtlasUtility
         foreach (string atlasGuid in atlasGuids)
         {
             string atlasPath = AssetDatabase.GUIDToAssetPath(atlasGuid);
-            if (IsManagedAtlasPath(atlasPath, atlasFolder))
+            if (!IsSpriteAtlasV2Path(atlasPath) || IsManagedAtlasPath(atlasPath, atlasFolder))
             {
                 continue;
             }
@@ -220,70 +246,9 @@ public static class IconCreatorSpriteAtlasUtility
         }
     }
 
-    private static void RebuildAtlas(
-        string atlasPath,
-        List<Sprite> sprites,
-        bool useSpriteAtlasV2)
+    private static void RebuildAtlas(string atlasPath, List<Sprite> sprites)
     {
-        if (useSpriteAtlasV2)
-        {
-            RebuildSpriteAtlasV2(atlasPath, sprites);
-        }
-        else
-        {
-            RebuildSpriteAtlasV1(atlasPath, sprites);
-        }
-    }
-
-    private static void RebuildSpriteAtlasV1(string atlasPath, List<Sprite> sprites)
-    {
-        SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
-        if (atlas == null)
-        {
-            atlas = new SpriteAtlas();
-            AssetDatabase.CreateAsset(atlas, atlasPath);
-            Undo.RegisterCreatedObjectUndo(atlas, "Create Thumbnail Sprite Atlas");
-        }
-        else
-        {
-            Undo.RecordObject(atlas, "Rebuild Thumbnail Sprite Atlas");
-        }
-
-        UnityEngine.Object[] currentPackables = SpriteAtlasExtensions.GetPackables(atlas);
-        if (currentPackables.Length > 0)
-        {
-            SpriteAtlasExtensions.Remove(atlas, currentPackables);
-        }
-
-        var packables = new UnityEngine.Object[sprites.Count];
-        for (int i = 0; i < sprites.Count; i++)
-        {
-            packables[i] = sprites[i];
-        }
-        if (packables.Length > 0)
-        {
-            SpriteAtlasExtensions.Add(atlas, packables);
-        }
-
-        SpriteAtlasPackingSettings packingSettings = SpriteAtlasExtensions.GetPackingSettings(atlas);
-        packingSettings.padding = 4;
-        packingSettings.enableRotation = false;
-        SpriteAtlasExtensions.SetPackingSettings(atlas, packingSettings);
-
-        SpriteAtlasTextureSettings textureSettings = SpriteAtlasExtensions.GetTextureSettings(atlas);
-        textureSettings.generateMipMaps = false;
-        textureSettings.filterMode = FilterMode.Bilinear;
-        textureSettings.sRGB = true;
-        SpriteAtlasExtensions.SetTextureSettings(atlas, textureSettings);
-
-        TextureImporterPlatformSettings platformSettings =
-            SpriteAtlasExtensions.GetPlatformSettings(atlas, "DefaultTexturePlatform");
-        platformSettings.maxTextureSize = 2048;
-        platformSettings.textureCompression = TextureImporterCompression.Compressed;
-        SpriteAtlasExtensions.SetPlatformSettings(atlas, platformSettings);
-        SpriteAtlasExtensions.SetIncludeInBuild(atlas, true);
-
-        EditorUtility.SetDirty(atlas);
+        RebuildSpriteAtlasV2(atlasPath, sprites);
     }
 
     private static void RebuildSpriteAtlasV2(string atlasPath, List<Sprite> sprites)
@@ -340,20 +305,16 @@ public static class IconCreatorSpriteAtlasUtility
 
     private static int ClearObsoleteAtlasPackables(
         string atlasFolder,
-        HashSet<string> rebuiltPaths,
-        bool useSpriteAtlasV2)
+        HashSet<string> rebuiltPaths)
     {
         int clearedCount = 0;
         string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { atlasFolder });
         for (int i = 0; i < atlasGuids.Length; i++)
         {
             string atlasPath = AssetDatabase.GUIDToAssetPath(atlasGuids[i]);
-            if (!IsManagedAtlasPath(atlasPath, atlasFolder) || rebuiltPaths.Contains(atlasPath))
-            {
-                continue;
-            }
-
-            if (IsSpriteAtlasV2Path(atlasPath) != useSpriteAtlasV2)
+            if (!IsSpriteAtlasV2Path(atlasPath) ||
+                !IsManagedAtlasPath(atlasPath, atlasFolder) ||
+                rebuiltPaths.Contains(atlasPath))
             {
                 continue;
             }
@@ -364,76 +325,37 @@ public static class IconCreatorSpriteAtlasUtility
                 continue;
             }
 
-            if (useSpriteAtlasV2)
-            {
-                SpriteAtlasAsset atlas = SpriteAtlasAsset.Load(atlasPath);
-                try
-                {
-                    SetSpriteAtlasV2Packables(atlas, Array.Empty<Sprite>());
-                    SpriteAtlasAsset.Save(atlas, atlasPath);
-                }
-                finally
-                {
-                    UnityEngine.Object.DestroyImmediate(atlas);
-                }
-                AssetDatabase.ImportAsset(atlasPath, ImportAssetOptions.ForceUpdate);
-            }
-            else
-            {
-                SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
-                Undo.RecordObject(atlas, "Clear Obsolete Thumbnail Sprite Atlas");
-                SpriteAtlasExtensions.Remove(atlas, packables);
-                EditorUtility.SetDirty(atlas);
-            }
-            clearedCount++;
-        }
-        return clearedCount;
-    }
-
-    private static int RemoveInactiveAtlasAssets(string atlasFolder, bool useSpriteAtlasV2)
-    {
-        int removedCount = 0;
-        string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { atlasFolder });
-        for (int i = 0; i < atlasGuids.Length; i++)
-        {
-            string atlasPath = AssetDatabase.GUIDToAssetPath(atlasGuids[i]);
-            if (!IsManagedAtlasPath(atlasPath, atlasFolder) ||
-                IsSpriteAtlasV2Path(atlasPath) == useSpriteAtlasV2)
-            {
-                continue;
-            }
-
-            if (AssetDatabase.DeleteAsset(atlasPath))
-            {
-                removedCount++;
-            }
-        }
-        return removedCount;
-    }
-
-    private static UnityEngine.Object[] GetAtlasPackables(string atlasPath)
-    {
-        if (IsSpriteAtlasV2Path(atlasPath))
-        {
             SpriteAtlasAsset atlas = SpriteAtlasAsset.Load(atlasPath);
-            if (atlas == null)
-            {
-                return Array.Empty<UnityEngine.Object>();
-            }
             try
             {
-                return GetSpriteAtlasV2Packables(atlas);
+                SetSpriteAtlasV2Packables(atlas, Array.Empty<Sprite>());
+                SpriteAtlasAsset.Save(atlas, atlasPath);
             }
             finally
             {
                 UnityEngine.Object.DestroyImmediate(atlas);
             }
+            AssetDatabase.ImportAsset(atlasPath, ImportAssetOptions.ForceUpdate);
+            clearedCount++;
         }
+        return clearedCount;
+    }
 
-        SpriteAtlas spriteAtlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
-        return spriteAtlas == null
-            ? Array.Empty<UnityEngine.Object>()
-            : SpriteAtlasExtensions.GetPackables(spriteAtlas);
+    private static UnityEngine.Object[] GetAtlasPackables(string atlasPath)
+    {
+        SpriteAtlasAsset atlas = SpriteAtlasAsset.Load(atlasPath);
+        if (atlas == null)
+        {
+            return Array.Empty<UnityEngine.Object>();
+        }
+        try
+        {
+            return GetSpriteAtlasV2Packables(atlas);
+        }
+        finally
+        {
+            UnityEngine.Object.DestroyImmediate(atlas);
+        }
     }
 
     private static UnityEngine.Object[] GetSpriteAtlasV2Packables(SpriteAtlasAsset atlas)
@@ -506,11 +428,10 @@ public static class IconCreatorSpriteAtlasUtility
     private static string GetUniqueAtlasPath(
         string atlasFolder,
         AtlasGroupKey groupKey,
-        HashSet<string> usedAtlasPaths,
-        bool useSpriteAtlasV2)
+        HashSet<string> usedAtlasPaths)
     {
         string baseName = AtlasNamePrefix + MakeAssetName(groupKey.Race) + "_" + MakeAssetName(groupKey.Region);
-        string extension = useSpriteAtlasV2 ? ".spriteatlasv2" : ".spriteatlas";
+        const string extension = ".spriteatlasv2";
         string atlasPath = atlasFolder + "/" + baseName + extension;
         int suffix = 2;
         while (!usedAtlasPaths.Add(atlasPath))
@@ -521,10 +442,22 @@ public static class IconCreatorSpriteAtlasUtility
         return atlasPath;
     }
 
+    public static bool IsSpriteAtlasV2Enabled()
+    {
+        return IsSpriteAtlasV2Enabled(EditorSettings.spritePackerMode);
+    }
+
     private static bool IsSpriteAtlasV2Enabled(SpritePackerMode spritePackerMode)
     {
-        return spritePackerMode == SpritePackerMode.SpriteAtlasV2 ||
-            spritePackerMode == SpritePackerMode.SpriteAtlasV2Build;
+        return spritePackerMode == SpritePackerMode.SpriteAtlasV2;
+    }
+
+    private static void EnsureSpriteAtlasV2Enabled(SpritePackerMode spritePackerMode)
+    {
+        if (!IsSpriteAtlasV2Enabled(spritePackerMode))
+        {
+            throw new InvalidOperationException(SpriteAtlasV2RequiredMessage);
+        }
     }
 
     private static bool IsSpriteAtlasV2Path(string atlasPath)

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
@@ -9,6 +9,8 @@ using UnityEditor.U2D;
 using UnityEngine;
 using UnityEngine.U2D;
 
+// Builds optional Sprite Atlas V2 assets from recipe thumbnails under the configured Icon Creator root.
+// Recipes continue referencing their source Sprites; Unity resolves those Sprites to included atlases.
 public static class IconCreatorSpriteAtlasUtility
 {
     private const string AtlasFolderName = "SpriteAtlases";
@@ -121,6 +123,8 @@ public static class IconCreatorSpriteAtlasUtility
         {
             recipePaths.Add(AssetDatabase.GUIDToAssetPath(recipeGuids[i]));
         }
+        // Stable recipe order makes atlas contents repeatable and makes the first assignment win
+        // predictably when the same Sprite is referenced by conflicting race/region groups.
         recipePaths.Sort(ComparePaths);
         recipeCount = 0;
 
@@ -299,6 +303,7 @@ public static class IconCreatorSpriteAtlasUtility
         platformSettings.maxTextureSize = 2048;
         platformSettings.textureCompression = TextureImporterCompression.Compressed;
         importer.SetPlatformSettings(platformSettings);
+        // Included atlases let Unity bind the original recipe Sprite references automatically in builds.
         importer.includeInBuild = true;
         importer.SaveAndReimport();
     }
@@ -307,6 +312,8 @@ public static class IconCreatorSpriteAtlasUtility
         string atlasFolder,
         HashSet<string> rebuiltPaths)
     {
+        // Keep obsolete managed atlas assets but empty their packables. Deleting or recreating them
+        // would churn their .meta GUIDs and could break references outside this tool.
         int clearedCount = 0;
         string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { atlasFolder });
         for (int i = 0; i < atlasGuids.Length; i++)
@@ -387,6 +394,8 @@ public static class IconCreatorSpriteAtlasUtility
         SpriteAtlasAsset atlas,
         IList<Sprite> sprites)
     {
+        // SpriteAtlasAsset exposes no public packable setter in V2, so update the same serialized list
+        // read by GetSpriteAtlasV2Packables before saving through SpriteAtlasAsset.Save.
         var serializedAtlas = new SerializedObject(atlas);
         SerializedProperty packablesProperty =
             serializedAtlas.FindProperty("m_ImporterData.packables");
@@ -467,6 +476,8 @@ public static class IconCreatorSpriteAtlasUtility
 
     private static bool AssetFileExists(string assetPath)
     {
+        // AssetDatabase can retain a stale path after an atlas file is removed outside Unity.
+        // Check the project file directly before choosing between load and create.
         string projectFolder = Directory.GetParent(Application.dataPath).FullName;
         string absolutePath = Path.GetFullPath(Path.Combine(projectFolder, assetPath));
         return File.Exists(absolutePath);

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
@@ -1,0 +1,480 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UMA.CharacterSystem;
+using UnityEditor;
+using UnityEditor.U2D;
+using UnityEngine;
+using UnityEngine.U2D;
+
+public static class IconCreatorSpriteAtlasUtility
+{
+    private const string AtlasFolderName = "SpriteAtlases";
+    private const string AtlasNamePrefix = "UMAIcons_";
+
+    public sealed class RebuildResult
+    {
+        public string OutputFolder { get; }
+        public int RecipeCount { get; }
+        public int SpriteCount { get; }
+        public int AtlasCount { get; }
+        public int ClearedAtlasCount { get; }
+        public int WarningCount { get; }
+
+        public RebuildResult(
+            string outputFolder,
+            int recipeCount,
+            int spriteCount,
+            int atlasCount,
+            int clearedAtlasCount,
+            int warningCount)
+        {
+            OutputFolder = outputFolder;
+            RecipeCount = recipeCount;
+            SpriteCount = spriteCount;
+            AtlasCount = atlasCount;
+            ClearedAtlasCount = clearedAtlasCount;
+            WarningCount = warningCount;
+        }
+    }
+
+    public static string GetAtlasFolder(string rootFolder)
+    {
+        return GetAssetRootFolder(rootFolder) + "/" + AtlasFolderName;
+    }
+
+    public static RebuildResult Rebuild(string rootFolder)
+    {
+        string atlasFolder = GetAtlasFolder(rootFolder);
+        EnsureAssetFolder(atlasFolder);
+
+        var warnings = new List<string>();
+        var sourceAssignments = new Dictionary<string, AtlasGroupKey>(StringComparer.OrdinalIgnoreCase);
+        int recipeCount;
+        Dictionary<AtlasGroupKey, HashSet<Sprite>> groups = CollectGroups(
+            sourceAssignments,
+            warnings,
+            out recipeCount);
+
+        WarnAboutExternalAtlasAssignments(sourceAssignments, atlasFolder, warnings);
+
+        var groupKeys = new List<AtlasGroupKey>(groups.Keys);
+        groupKeys.Sort(CompareGroupKeys);
+        var rebuiltPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var usedAtlasPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int spriteCount = 0;
+
+        for (int i = 0; i < groupKeys.Count; i++)
+        {
+            AtlasGroupKey groupKey = groupKeys[i];
+            List<Sprite> sprites = GetSortedSprites(groups[groupKey]);
+            string atlasPath = GetUniqueAtlasPath(atlasFolder, groupKey, usedAtlasPaths);
+            RebuildAtlas(atlasPath, sprites);
+            rebuiltPaths.Add(atlasPath);
+            spriteCount += sprites.Count;
+        }
+
+        int clearedAtlasCount = ClearObsoleteAtlasPackables(atlasFolder, rebuiltPaths);
+        AssetDatabase.SaveAssets();
+
+        for (int i = 0; i < warnings.Count; i++)
+        {
+            Debug.LogWarning("[IconCreator] " + warnings[i]);
+        }
+
+        return new RebuildResult(
+            atlasFolder,
+            recipeCount,
+            spriteCount,
+            groupKeys.Count,
+            clearedAtlasCount,
+            warnings.Count);
+    }
+
+    private static Dictionary<AtlasGroupKey, HashSet<Sprite>> CollectGroups(
+        Dictionary<string, AtlasGroupKey> sourceAssignments,
+        List<string> warnings,
+        out int recipeCount)
+    {
+        var groups = new Dictionary<AtlasGroupKey, HashSet<Sprite>>();
+        string[] recipeGuids = AssetDatabase.FindAssets("t:UMAWardrobeRecipe");
+        var recipePaths = new List<string>(recipeGuids.Length);
+        for (int i = 0; i < recipeGuids.Length; i++)
+        {
+            recipePaths.Add(AssetDatabase.GUIDToAssetPath(recipeGuids[i]));
+        }
+        recipePaths.Sort(ComparePaths);
+        recipeCount = 0;
+
+        for (int i = 0; i < recipePaths.Count; i++)
+        {
+            UMAWardrobeRecipe recipe = AssetDatabase.LoadAssetAtPath<UMAWardrobeRecipe>(recipePaths[i]);
+            if (recipe == null || recipe.wardrobeRecipeThumbs == null || string.IsNullOrEmpty(recipe.wardrobeSlot))
+            {
+                continue;
+            }
+
+            bool hasReferencedThumbnail = false;
+            for (int thumbIndex = 0; thumbIndex < recipe.wardrobeRecipeThumbs.Count; thumbIndex++)
+            {
+                WardrobeRecipeThumb thumbnail = recipe.wardrobeRecipeThumbs[thumbIndex];
+                if (thumbnail == null || thumbnail.thumb == null || string.IsNullOrEmpty(thumbnail.race))
+                {
+                    continue;
+                }
+
+                string sourcePath = AssetDatabase.GetAssetPath(thumbnail.thumb);
+                if (string.IsNullOrEmpty(sourcePath))
+                {
+                    continue;
+                }
+                hasReferencedThumbnail = true;
+
+                var groupKey = new AtlasGroupKey(thumbnail.race, recipe.wardrobeSlot);
+                if (sourceAssignments.TryGetValue(sourcePath, out AtlasGroupKey assignedGroup))
+                {
+                    if (!assignedGroup.Equals(groupKey))
+                    {
+                        warnings.Add(
+                            "Sprite '" + sourcePath + "' is referenced by conflicting thumbnail groups " +
+                            assignedGroup + " and " + groupKey + ". It remains assigned to " + assignedGroup + ".");
+                    }
+                    continue;
+                }
+
+                sourceAssignments.Add(sourcePath, groupKey);
+                if (!groups.TryGetValue(groupKey, out HashSet<Sprite> sprites))
+                {
+                    sprites = new HashSet<Sprite>();
+                    groups.Add(groupKey, sprites);
+                }
+                sprites.Add(thumbnail.thumb);
+            }
+
+            if (hasReferencedThumbnail)
+            {
+                recipeCount++;
+            }
+        }
+
+        return groups;
+    }
+
+    private static void WarnAboutExternalAtlasAssignments(
+        Dictionary<string, AtlasGroupKey> sourceAssignments,
+        string atlasFolder,
+        List<string> warnings)
+    {
+        string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas");
+        var reportedConflicts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string atlasGuid in atlasGuids)
+        {
+            string atlasPath = AssetDatabase.GUIDToAssetPath(atlasGuid);
+            if (IsManagedAtlasPath(atlasPath, atlasFolder))
+            {
+                continue;
+            }
+
+            SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+            if (atlas == null)
+            {
+                continue;
+            }
+
+            UnityEngine.Object[] packables = SpriteAtlasExtensions.GetPackables(atlas);
+            for (int i = 0; i < packables.Length; i++)
+            {
+                string packablePath = AssetDatabase.GetAssetPath(packables[i]);
+                if (string.IsNullOrEmpty(packablePath))
+                {
+                    continue;
+                }
+
+                foreach (KeyValuePair<string, AtlasGroupKey> assignment in sourceAssignments)
+                {
+                    bool isFolderAssignment = AssetDatabase.IsValidFolder(packablePath) &&
+                        assignment.Key.StartsWith(packablePath + "/", StringComparison.OrdinalIgnoreCase);
+                    if (!assignment.Key.Equals(packablePath, StringComparison.OrdinalIgnoreCase) && !isFolderAssignment)
+                    {
+                        continue;
+                    }
+
+                    string conflictKey = assignment.Key + "|" + atlasPath;
+                    if (reportedConflicts.Add(conflictKey))
+                    {
+                        warnings.Add(
+                            "Sprite '" + assignment.Key + "' is already packable in atlas '" + atlasPath +
+                            "' and will also be assigned to " + assignment.Value + ".");
+                    }
+                }
+            }
+        }
+    }
+
+    private static void RebuildAtlas(string atlasPath, List<Sprite> sprites)
+    {
+        SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+        if (atlas == null)
+        {
+            atlas = new SpriteAtlas();
+            AssetDatabase.CreateAsset(atlas, atlasPath);
+            Undo.RegisterCreatedObjectUndo(atlas, "Create Thumbnail Sprite Atlas");
+        }
+        else
+        {
+            Undo.RecordObject(atlas, "Rebuild Thumbnail Sprite Atlas");
+        }
+
+        UnityEngine.Object[] currentPackables = SpriteAtlasExtensions.GetPackables(atlas);
+        if (currentPackables.Length > 0)
+        {
+            SpriteAtlasExtensions.Remove(atlas, currentPackables);
+        }
+
+        var packables = new UnityEngine.Object[sprites.Count];
+        for (int i = 0; i < sprites.Count; i++)
+        {
+            packables[i] = sprites[i];
+        }
+        if (packables.Length > 0)
+        {
+            SpriteAtlasExtensions.Add(atlas, packables);
+        }
+
+        SpriteAtlasPackingSettings packingSettings = SpriteAtlasExtensions.GetPackingSettings(atlas);
+        packingSettings.padding = 4;
+        packingSettings.enableRotation = false;
+        SpriteAtlasExtensions.SetPackingSettings(atlas, packingSettings);
+
+        SpriteAtlasTextureSettings textureSettings = SpriteAtlasExtensions.GetTextureSettings(atlas);
+        textureSettings.generateMipMaps = false;
+        textureSettings.filterMode = FilterMode.Bilinear;
+        textureSettings.sRGB = true;
+        SpriteAtlasExtensions.SetTextureSettings(atlas, textureSettings);
+
+        TextureImporterPlatformSettings platformSettings =
+            SpriteAtlasExtensions.GetPlatformSettings(atlas, "DefaultTexturePlatform");
+        platformSettings.maxTextureSize = 2048;
+        platformSettings.textureCompression = TextureImporterCompression.Compressed;
+        SpriteAtlasExtensions.SetPlatformSettings(atlas, platformSettings);
+        SpriteAtlasExtensions.SetIncludeInBuild(atlas, true);
+
+        EditorUtility.SetDirty(atlas);
+    }
+
+    private static int ClearObsoleteAtlasPackables(
+        string atlasFolder,
+        HashSet<string> rebuiltPaths)
+    {
+        int clearedCount = 0;
+        string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { atlasFolder });
+        for (int i = 0; i < atlasGuids.Length; i++)
+        {
+            string atlasPath = AssetDatabase.GUIDToAssetPath(atlasGuids[i]);
+            if (!IsManagedAtlasPath(atlasPath, atlasFolder) || rebuiltPaths.Contains(atlasPath))
+            {
+                continue;
+            }
+
+            SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+            if (atlas == null)
+            {
+                continue;
+            }
+            UnityEngine.Object[] packables = SpriteAtlasExtensions.GetPackables(atlas);
+            if (packables.Length == 0)
+            {
+                continue;
+            }
+
+            Undo.RecordObject(atlas, "Clear Obsolete Thumbnail Sprite Atlas");
+            SpriteAtlasExtensions.Remove(atlas, packables);
+            EditorUtility.SetDirty(atlas);
+            clearedCount++;
+        }
+        return clearedCount;
+    }
+
+    private static List<Sprite> GetSortedSprites(HashSet<Sprite> sourceSprites)
+    {
+        var sprites = new List<Sprite>(sourceSprites);
+        sprites.Sort((left, right) =>
+        {
+            int pathComparison = ComparePaths(
+                AssetDatabase.GetAssetPath(left),
+                AssetDatabase.GetAssetPath(right));
+            if (pathComparison != 0)
+            {
+                return pathComparison;
+            }
+            int nameComparison = string.Compare(left.name, right.name, StringComparison.OrdinalIgnoreCase);
+            if (nameComparison != 0)
+            {
+                return nameComparison;
+            }
+            return string.Compare(left.name, right.name, StringComparison.Ordinal);
+        });
+        return sprites;
+    }
+
+    private static string GetUniqueAtlasPath(
+        string atlasFolder,
+        AtlasGroupKey groupKey,
+        HashSet<string> usedAtlasPaths)
+    {
+        string baseName = AtlasNamePrefix + MakeAssetName(groupKey.Race) + "_" + MakeAssetName(groupKey.Region);
+        string atlasPath = atlasFolder + "/" + baseName + ".spriteatlas";
+        int suffix = 2;
+        while (!usedAtlasPaths.Add(atlasPath))
+        {
+            atlasPath = atlasFolder + "/" + baseName + "_" + suffix + ".spriteatlas";
+            suffix++;
+        }
+        return atlasPath;
+    }
+
+    private static string MakeAssetName(string value)
+    {
+        var result = new StringBuilder(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            char character = value[i];
+            if (char.IsLetterOrDigit(character) || character == '_' || character == '-')
+            {
+                result.Append(character);
+            }
+        }
+        return result.Length > 0 ? result.ToString() : "Unnamed";
+    }
+
+    private static string GetAssetRootFolder(string rootFolder)
+    {
+        string dataPath = Path.GetFullPath(Application.dataPath).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string projectPath = Directory.GetParent(dataPath).FullName;
+        string rootPath;
+        if (string.IsNullOrWhiteSpace(rootFolder))
+        {
+            rootPath = dataPath;
+        }
+        else if (Path.IsPathRooted(rootFolder))
+        {
+            rootPath = Path.GetFullPath(rootFolder);
+        }
+        else
+        {
+            string normalizedRoot = rootFolder.Replace('\\', '/').Trim('/');
+            if (normalizedRoot.Equals("Assets", StringComparison.OrdinalIgnoreCase) ||
+                normalizedRoot.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+            {
+                rootPath = Path.GetFullPath(Path.Combine(projectPath, normalizedRoot));
+            }
+            else
+            {
+                rootPath = Path.GetFullPath(Path.Combine(dataPath, normalizedRoot));
+            }
+        }
+
+        rootPath = rootPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (!rootPath.Equals(dataPath, StringComparison.OrdinalIgnoreCase) &&
+            !rootPath.StartsWith(dataPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Thumbnail Sprite Atlases must be created inside the project's Assets folder.");
+        }
+
+        string relativePath = rootPath.Substring(dataPath.Length).Replace('\\', '/');
+        return "Assets" + relativePath;
+    }
+
+    private static void EnsureAssetFolder(string assetFolder)
+    {
+        string[] folderParts = assetFolder.Split('/');
+        string currentFolder = folderParts[0];
+        for (int i = 1; i < folderParts.Length; i++)
+        {
+            string nextFolder = currentFolder + "/" + folderParts[i];
+            if (!AssetDatabase.IsValidFolder(nextFolder))
+            {
+                AssetDatabase.CreateFolder(currentFolder, folderParts[i]);
+            }
+            currentFolder = nextFolder;
+        }
+    }
+
+    private static bool IsManagedAtlasPath(string atlasPath, string atlasFolder)
+    {
+        string directory = Path.GetDirectoryName(atlasPath)?.Replace('\\', '/');
+        string fileName = Path.GetFileName(atlasPath);
+        return directory != null &&
+            directory.Equals(atlasFolder, StringComparison.OrdinalIgnoreCase) &&
+            fileName.StartsWith(AtlasNamePrefix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int CompareGroupKeys(AtlasGroupKey left, AtlasGroupKey right)
+    {
+        int raceComparison = string.Compare(left.Race, right.Race, StringComparison.OrdinalIgnoreCase);
+        if (raceComparison != 0)
+        {
+            return raceComparison;
+        }
+        int regionComparison = string.Compare(left.Region, right.Region, StringComparison.OrdinalIgnoreCase);
+        if (regionComparison != 0)
+        {
+            return regionComparison;
+        }
+
+        raceComparison = string.Compare(left.Race, right.Race, StringComparison.Ordinal);
+        if (raceComparison != 0)
+        {
+            return raceComparison;
+        }
+        return string.Compare(left.Region, right.Region, StringComparison.Ordinal);
+    }
+
+    private static int ComparePaths(string left, string right)
+    {
+        int comparison = string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+        return comparison != 0
+            ? comparison
+            : string.Compare(left, right, StringComparison.Ordinal);
+    }
+
+    private readonly struct AtlasGroupKey : IEquatable<AtlasGroupKey>
+    {
+        public string Race { get; }
+        public string Region { get; }
+
+        public AtlasGroupKey(string race, string region)
+        {
+            Race = race;
+            Region = region;
+        }
+
+        public bool Equals(AtlasGroupKey other)
+        {
+            return string.Equals(Race, other.Race, StringComparison.Ordinal) &&
+                string.Equals(Region, other.Region, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AtlasGroupKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Race != null ? Race.GetHashCode() : 0) * 397) ^
+                    (Region != null ? Region.GetHashCode() : 0);
+            }
+        }
+
+        public override string ToString()
+        {
+            return "'" + Race + "/" + Region + "'";
+        }
+    }
+}
+#endif

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
@@ -288,9 +288,9 @@ public static class IconCreatorSpriteAtlasUtility
 
     private static void RebuildSpriteAtlasV2(string atlasPath, List<Sprite> sprites)
     {
-        SpriteAtlasAsset atlas = string.IsNullOrEmpty(AssetDatabase.AssetPathToGUID(atlasPath))
-            ? new SpriteAtlasAsset()
-            : SpriteAtlasAsset.Load(atlasPath);
+        SpriteAtlasAsset atlas = AssetFileExists(atlasPath)
+            ? SpriteAtlasAsset.Load(atlasPath)
+            : new SpriteAtlasAsset();
         if (atlas == null)
         {
             throw new InvalidOperationException("Unable to load Sprite Atlas V2 asset at '" + atlasPath + "'.");
@@ -530,6 +530,13 @@ public static class IconCreatorSpriteAtlasUtility
     private static bool IsSpriteAtlasV2Path(string atlasPath)
     {
         return atlasPath.EndsWith(".spriteatlasv2", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool AssetFileExists(string assetPath)
+    {
+        string projectFolder = Directory.GetParent(Application.dataPath).FullName;
+        string absolutePath = Path.GetFullPath(Path.Combine(projectFolder, assetPath));
+        return File.Exists(absolutePath);
     }
 
     private static string MakeAssetName(string value)

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs
@@ -21,6 +21,7 @@ public static class IconCreatorSpriteAtlasUtility
         public int SpriteCount { get; }
         public int AtlasCount { get; }
         public int ClearedAtlasCount { get; }
+        public int RemovedAtlasCount { get; }
         public int WarningCount { get; }
 
         public RebuildResult(
@@ -29,6 +30,7 @@ public static class IconCreatorSpriteAtlasUtility
             int spriteCount,
             int atlasCount,
             int clearedAtlasCount,
+            int removedAtlasCount,
             int warningCount)
         {
             OutputFolder = outputFolder;
@@ -36,6 +38,7 @@ public static class IconCreatorSpriteAtlasUtility
             SpriteCount = spriteCount;
             AtlasCount = atlasCount;
             ClearedAtlasCount = clearedAtlasCount;
+            RemovedAtlasCount = removedAtlasCount;
             WarningCount = warningCount;
         }
     }
@@ -64,19 +67,28 @@ public static class IconCreatorSpriteAtlasUtility
         groupKeys.Sort(CompareGroupKeys);
         var rebuiltPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var usedAtlasPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        bool useSpriteAtlasV2 = IsSpriteAtlasV2Enabled(EditorSettings.spritePackerMode);
         int spriteCount = 0;
 
         for (int i = 0; i < groupKeys.Count; i++)
         {
             AtlasGroupKey groupKey = groupKeys[i];
             List<Sprite> sprites = GetSortedSprites(groups[groupKey]);
-            string atlasPath = GetUniqueAtlasPath(atlasFolder, groupKey, usedAtlasPaths);
-            RebuildAtlas(atlasPath, sprites);
+            string atlasPath = GetUniqueAtlasPath(
+                atlasFolder,
+                groupKey,
+                usedAtlasPaths,
+                useSpriteAtlasV2);
+            RebuildAtlas(atlasPath, sprites, useSpriteAtlasV2);
             rebuiltPaths.Add(atlasPath);
             spriteCount += sprites.Count;
         }
 
-        int clearedAtlasCount = ClearObsoleteAtlasPackables(atlasFolder, rebuiltPaths);
+        int clearedAtlasCount = ClearObsoleteAtlasPackables(
+            atlasFolder,
+            rebuiltPaths,
+            useSpriteAtlasV2);
+        int removedAtlasCount = RemoveInactiveAtlasAssets(atlasFolder, useSpriteAtlasV2);
         AssetDatabase.SaveAssets();
 
         for (int i = 0; i < warnings.Count; i++)
@@ -90,6 +102,7 @@ public static class IconCreatorSpriteAtlasUtility
             spriteCount,
             groupKeys.Count,
             clearedAtlasCount,
+            removedAtlasCount,
             warnings.Count);
     }
 
@@ -177,13 +190,7 @@ public static class IconCreatorSpriteAtlasUtility
                 continue;
             }
 
-            SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
-            if (atlas == null)
-            {
-                continue;
-            }
-
-            UnityEngine.Object[] packables = SpriteAtlasExtensions.GetPackables(atlas);
+            UnityEngine.Object[] packables = GetAtlasPackables(atlasPath);
             for (int i = 0; i < packables.Length; i++)
             {
                 string packablePath = AssetDatabase.GetAssetPath(packables[i]);
@@ -213,7 +220,22 @@ public static class IconCreatorSpriteAtlasUtility
         }
     }
 
-    private static void RebuildAtlas(string atlasPath, List<Sprite> sprites)
+    private static void RebuildAtlas(
+        string atlasPath,
+        List<Sprite> sprites,
+        bool useSpriteAtlasV2)
+    {
+        if (useSpriteAtlasV2)
+        {
+            RebuildSpriteAtlasV2(atlasPath, sprites);
+        }
+        else
+        {
+            RebuildSpriteAtlasV1(atlasPath, sprites);
+        }
+    }
+
+    private static void RebuildSpriteAtlasV1(string atlasPath, List<Sprite> sprites)
     {
         SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
         if (atlas == null)
@@ -264,9 +286,62 @@ public static class IconCreatorSpriteAtlasUtility
         EditorUtility.SetDirty(atlas);
     }
 
+    private static void RebuildSpriteAtlasV2(string atlasPath, List<Sprite> sprites)
+    {
+        SpriteAtlasAsset atlas = string.IsNullOrEmpty(AssetDatabase.AssetPathToGUID(atlasPath))
+            ? new SpriteAtlasAsset()
+            : SpriteAtlasAsset.Load(atlasPath);
+        if (atlas == null)
+        {
+            throw new InvalidOperationException("Unable to load Sprite Atlas V2 asset at '" + atlasPath + "'.");
+        }
+
+        try
+        {
+            SetSpriteAtlasV2Packables(atlas, sprites);
+            SpriteAtlasAsset.Save(atlas, atlasPath);
+        }
+        finally
+        {
+            UnityEngine.Object.DestroyImmediate(atlas);
+        }
+
+        AssetDatabase.ImportAsset(atlasPath, ImportAssetOptions.ForceUpdate);
+        ConfigureSpriteAtlasV2Importer(atlasPath);
+    }
+
+    private static void ConfigureSpriteAtlasV2Importer(string atlasPath)
+    {
+        SpriteAtlasImporter importer = AssetImporter.GetAtPath(atlasPath) as SpriteAtlasImporter;
+        if (importer == null)
+        {
+            throw new InvalidOperationException("Unable to load Sprite Atlas V2 importer at '" + atlasPath + "'.");
+        }
+
+        SpriteAtlasPackingSettings packingSettings = importer.packingSettings;
+        packingSettings.padding = 4;
+        packingSettings.enableRotation = false;
+        importer.packingSettings = packingSettings;
+
+        SpriteAtlasTextureSettings textureSettings = importer.textureSettings;
+        textureSettings.generateMipMaps = false;
+        textureSettings.filterMode = FilterMode.Bilinear;
+        textureSettings.sRGB = true;
+        importer.textureSettings = textureSettings;
+
+        TextureImporterPlatformSettings platformSettings =
+            importer.GetPlatformSettings("DefaultTexturePlatform");
+        platformSettings.maxTextureSize = 2048;
+        platformSettings.textureCompression = TextureImporterCompression.Compressed;
+        importer.SetPlatformSettings(platformSettings);
+        importer.includeInBuild = true;
+        importer.SaveAndReimport();
+    }
+
     private static int ClearObsoleteAtlasPackables(
         string atlasFolder,
-        HashSet<string> rebuiltPaths)
+        HashSet<string> rebuiltPaths,
+        bool useSpriteAtlasV2)
     {
         int clearedCount = 0;
         string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { atlasFolder });
@@ -278,23 +353,132 @@ public static class IconCreatorSpriteAtlasUtility
                 continue;
             }
 
-            SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
-            if (atlas == null)
+            if (IsSpriteAtlasV2Path(atlasPath) != useSpriteAtlasV2)
             {
                 continue;
             }
-            UnityEngine.Object[] packables = SpriteAtlasExtensions.GetPackables(atlas);
+
+            UnityEngine.Object[] packables = GetAtlasPackables(atlasPath);
             if (packables.Length == 0)
             {
                 continue;
             }
 
-            Undo.RecordObject(atlas, "Clear Obsolete Thumbnail Sprite Atlas");
-            SpriteAtlasExtensions.Remove(atlas, packables);
-            EditorUtility.SetDirty(atlas);
+            if (useSpriteAtlasV2)
+            {
+                SpriteAtlasAsset atlas = SpriteAtlasAsset.Load(atlasPath);
+                try
+                {
+                    SetSpriteAtlasV2Packables(atlas, Array.Empty<Sprite>());
+                    SpriteAtlasAsset.Save(atlas, atlasPath);
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(atlas);
+                }
+                AssetDatabase.ImportAsset(atlasPath, ImportAssetOptions.ForceUpdate);
+            }
+            else
+            {
+                SpriteAtlas atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+                Undo.RecordObject(atlas, "Clear Obsolete Thumbnail Sprite Atlas");
+                SpriteAtlasExtensions.Remove(atlas, packables);
+                EditorUtility.SetDirty(atlas);
+            }
             clearedCount++;
         }
         return clearedCount;
+    }
+
+    private static int RemoveInactiveAtlasAssets(string atlasFolder, bool useSpriteAtlasV2)
+    {
+        int removedCount = 0;
+        string[] atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas", new[] { atlasFolder });
+        for (int i = 0; i < atlasGuids.Length; i++)
+        {
+            string atlasPath = AssetDatabase.GUIDToAssetPath(atlasGuids[i]);
+            if (!IsManagedAtlasPath(atlasPath, atlasFolder) ||
+                IsSpriteAtlasV2Path(atlasPath) == useSpriteAtlasV2)
+            {
+                continue;
+            }
+
+            if (AssetDatabase.DeleteAsset(atlasPath))
+            {
+                removedCount++;
+            }
+        }
+        return removedCount;
+    }
+
+    private static UnityEngine.Object[] GetAtlasPackables(string atlasPath)
+    {
+        if (IsSpriteAtlasV2Path(atlasPath))
+        {
+            SpriteAtlasAsset atlas = SpriteAtlasAsset.Load(atlasPath);
+            if (atlas == null)
+            {
+                return Array.Empty<UnityEngine.Object>();
+            }
+            try
+            {
+                return GetSpriteAtlasV2Packables(atlas);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(atlas);
+            }
+        }
+
+        SpriteAtlas spriteAtlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+        return spriteAtlas == null
+            ? Array.Empty<UnityEngine.Object>()
+            : SpriteAtlasExtensions.GetPackables(spriteAtlas);
+    }
+
+    private static UnityEngine.Object[] GetSpriteAtlasV2Packables(SpriteAtlasAsset atlas)
+    {
+        // SpriteAtlasAsset has no public packable getter. Its serialized packable list is
+        // the source data written by SpriteAtlasAsset.Save.
+        var serializedAtlas = new SerializedObject(atlas);
+        SerializedProperty packablesProperty =
+            serializedAtlas.FindProperty("m_ImporterData.packables");
+        if (packablesProperty == null || !packablesProperty.isArray)
+        {
+            return Array.Empty<UnityEngine.Object>();
+        }
+
+        var packables = new List<UnityEngine.Object>(packablesProperty.arraySize);
+        for (int i = 0; i < packablesProperty.arraySize; i++)
+        {
+            UnityEngine.Object packable =
+                packablesProperty.GetArrayElementAtIndex(i).objectReferenceValue;
+            if (packable != null)
+            {
+                packables.Add(packable);
+            }
+        }
+        return packables.ToArray();
+    }
+
+    private static void SetSpriteAtlasV2Packables(
+        SpriteAtlasAsset atlas,
+        IList<Sprite> sprites)
+    {
+        var serializedAtlas = new SerializedObject(atlas);
+        SerializedProperty packablesProperty =
+            serializedAtlas.FindProperty("m_ImporterData.packables");
+        if (packablesProperty == null || !packablesProperty.isArray)
+        {
+            throw new InvalidOperationException("Unable to access Sprite Atlas V2 packables.");
+        }
+
+        packablesProperty.arraySize = sprites.Count;
+        for (int i = 0; i < sprites.Count; i++)
+        {
+            packablesProperty.GetArrayElementAtIndex(i).objectReferenceValue = sprites[i];
+        }
+        serializedAtlas.ApplyModifiedPropertiesWithoutUndo();
     }
 
     private static List<Sprite> GetSortedSprites(HashSet<Sprite> sourceSprites)
@@ -322,17 +506,30 @@ public static class IconCreatorSpriteAtlasUtility
     private static string GetUniqueAtlasPath(
         string atlasFolder,
         AtlasGroupKey groupKey,
-        HashSet<string> usedAtlasPaths)
+        HashSet<string> usedAtlasPaths,
+        bool useSpriteAtlasV2)
     {
         string baseName = AtlasNamePrefix + MakeAssetName(groupKey.Race) + "_" + MakeAssetName(groupKey.Region);
-        string atlasPath = atlasFolder + "/" + baseName + ".spriteatlas";
+        string extension = useSpriteAtlasV2 ? ".spriteatlasv2" : ".spriteatlas";
+        string atlasPath = atlasFolder + "/" + baseName + extension;
         int suffix = 2;
         while (!usedAtlasPaths.Add(atlasPath))
         {
-            atlasPath = atlasFolder + "/" + baseName + "_" + suffix + ".spriteatlas";
+            atlasPath = atlasFolder + "/" + baseName + "_" + suffix + extension;
             suffix++;
         }
         return atlasPath;
+    }
+
+    private static bool IsSpriteAtlasV2Enabled(SpritePackerMode spritePackerMode)
+    {
+        return spritePackerMode == SpritePackerMode.SpriteAtlasV2 ||
+            spritePackerMode == SpritePackerMode.SpriteAtlasV2Build;
+    }
+
+    private static bool IsSpriteAtlasV2Path(string atlasPath)
+    {
+        return atlasPath.EndsWith(".spriteatlasv2", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string MakeAssetName(string value)

--- a/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs.meta
+++ b/UMAProject/Assets/UMA/Core/Editor/Extensions/DynamicCharacterSystem/IconCreatorSpriteAtlasUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f115b82c9d894c4d8d62d802f3d46155

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
@@ -1,13 +1,14 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
+using UMA.CharacterSystem;
 using UnityEditor;
 using UnityEditor.U2D;
 using UnityEngine;
-using UnityEngine.U2D;
 
 namespace UMA.Editors.Tests
 {
@@ -36,17 +37,126 @@ namespace UMA.Editors.Tests
         [Test]
         [Category("UMA")]
         [Category("IconCreator")]
+        public void ThumbnailSourcesAreRestrictedToTheConfiguredIconRoot()
+        {
+            const string iconRoot = "Assets/UMA/UMA3/Wearables/Icons";
+            const string atlasFolder = iconRoot + "/SpriteAtlases";
+
+            Assert.IsTrue((bool)InvokePrivateStatic(
+                "IsThumbnailSourcePath",
+                iconRoot + "/Hair/Human Female 3.0/Hair.png",
+                iconRoot,
+                atlasFolder));
+            Assert.IsFalse((bool)InvokePrivateStatic(
+                "IsThumbnailSourcePath",
+                "Assets/UMA2/Wearables/Thumbs/Hair.png",
+                iconRoot,
+                atlasFolder));
+            Assert.IsFalse((bool)InvokePrivateStatic(
+                "IsThumbnailSourcePath",
+                "Assets/UMA/UMA3/Wearables/IconsLegacy/Hair.png",
+                iconRoot,
+                atlasFolder));
+            Assert.IsFalse((bool)InvokePrivateStatic(
+                "IsThumbnailSourcePath",
+                atlasFolder + "/Generated.png",
+                iconRoot,
+                atlasFolder));
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void AtlasGroupsOnlyIncludeThumbnailSpritesUnderTheConfiguredRoot()
+        {
+            string folder = CreateTestFolder();
+            string iconRoot = folder + "/Icons";
+            string externalFolder = folder + "/External";
+            AssetDatabase.CreateFolder(folder, "Icons");
+            AssetDatabase.CreateFolder(folder, "External");
+            try
+            {
+                Sprite includedSprite = CreateSpriteAsset(iconRoot, "Included");
+                Sprite excludedSprite = CreateSpriteAsset(externalFolder, "Excluded");
+                CreateWardrobeRecipeAsset(
+                    folder,
+                    "IncludedRecipe",
+                    "IncludedRegion",
+                    "IncludedRace",
+                    includedSprite);
+                CreateWardrobeRecipeAsset(
+                    folder,
+                    "ExcludedRecipe",
+                    "ExcludedRegion",
+                    "ExcludedRace",
+                    excludedSprite);
+                AssetDatabase.SaveAssets();
+
+                Type groupKeyType = typeof(IconCreatorSpriteAtlasUtility).GetNestedType(
+                    "AtlasGroupKey",
+                    BindingFlags.NonPublic);
+                Assert.IsNotNull(groupKeyType);
+                Type assignmentsType = typeof(Dictionary<,>).MakeGenericType(
+                    typeof(string),
+                    groupKeyType);
+                IDictionary assignments = (IDictionary)Activator.CreateInstance(assignmentsType);
+                var warnings = new List<string>();
+                object[] arguments =
+                {
+                    iconRoot,
+                    iconRoot + "/SpriteAtlases",
+                    assignments,
+                    warnings,
+                    0
+                };
+
+                MethodInfo collectGroups = typeof(IconCreatorSpriteAtlasUtility).GetMethod(
+                    "CollectGroups",
+                    BindingFlags.Static | BindingFlags.NonPublic);
+                Assert.IsNotNull(collectGroups);
+                IDictionary groups = (IDictionary)collectGroups.Invoke(null, arguments);
+
+                Assert.AreEqual(1, groups.Count);
+                Assert.AreEqual(1, assignments.Count);
+                Assert.AreEqual(1, (int)arguments[4]);
+                Assert.AreEqual(0, warnings.Count);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folder);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
         public void SpriteAtlasV2ModesAreDetected()
         {
             Assert.IsTrue((bool)InvokePrivateStatic(
                 "IsSpriteAtlasV2Enabled",
                 SpritePackerMode.SpriteAtlasV2));
-            Assert.IsTrue((bool)InvokePrivateStatic(
+            Assert.IsFalse((bool)InvokePrivateStatic(
                 "IsSpriteAtlasV2Enabled",
                 SpritePackerMode.SpriteAtlasV2Build));
             Assert.IsFalse((bool)InvokePrivateStatic(
                 "IsSpriteAtlasV2Enabled",
                 SpritePackerMode.AlwaysOnAtlas));
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void AtlasRebuildRequiresSpriteAtlasV2EnabledInTheEditor()
+        {
+            TargetInvocationException exception = Assert.Throws<TargetInvocationException>(() =>
+                InvokePrivateStatic(
+                    "EnsureSpriteAtlasV2Enabled",
+                    SpritePackerMode.SpriteAtlasV2Build));
+
+            Assert.IsInstanceOf<InvalidOperationException>(exception.InnerException);
+            StringAssert.Contains(
+                "Sprite Atlas V2 - Enabled",
+                exception.InnerException.Message);
         }
 
         [Test]
@@ -64,8 +174,7 @@ namespace UMA.Editors.Tests
                 InvokePrivateStatic(
                     "RebuildAtlas",
                     atlasPath,
-                    new List<Sprite> { firstSprite, secondSprite },
-                    true);
+                    new List<Sprite> { firstSprite, secondSprite });
 
                 string originalGuid = AssetDatabase.AssetPathToGUID(atlasPath);
                 Assert.IsNotEmpty(originalGuid);
@@ -74,8 +183,7 @@ namespace UMA.Editors.Tests
                 InvokePrivateStatic(
                     "RebuildAtlas",
                     atlasPath,
-                    new List<Sprite> { secondSprite },
-                    true);
+                    new List<Sprite> { secondSprite });
 
                 Assert.AreEqual(originalGuid, AssetDatabase.AssetPathToGUID(atlasPath));
                 Assert.AreEqual(1, GetSpriteAtlasV2PackableCount(atlasPath));
@@ -97,7 +205,7 @@ namespace UMA.Editors.Tests
         [Test]
         [Category("UMA")]
         [Category("IconCreator")]
-        public void SpriteAtlasV2RebuildRecreatesDeletedAssetWithCachedGuid()
+        public void SpriteAtlasV2RebuildRecreatesDeletedAsset()
         {
             string folder = CreateTestFolder();
             string atlasPath = folder + "/UMAIcons_Deleted_TestRegion.spriteatlasv2";
@@ -121,49 +229,10 @@ namespace UMA.Editors.Tests
                 InvokePrivateStatic(
                     "RebuildAtlas",
                     atlasPath,
-                    new List<Sprite> { sprite },
-                    true);
+                    new List<Sprite> { sprite });
 
                 Assert.IsTrue(File.Exists(Path.GetFullPath(atlasPath)));
                 Assert.AreEqual(1, GetSpriteAtlasV2PackableCount(atlasPath));
-            }
-            finally
-            {
-                AssetDatabase.DeleteAsset(folder);
-            }
-        }
-
-        [Test]
-        [Category("UMA")]
-        [Category("IconCreator")]
-        public void InactiveGeneratedAtlasVersionIsRemoved()
-        {
-            string folder = CreateTestFolder();
-            string atlasName = "/UMAIcons_TestRace_TestRegion";
-            string v1Path = folder + atlasName + ".spriteatlas";
-            string v2Path = folder + atlasName + ".spriteatlasv2";
-            try
-            {
-                AssetDatabase.CreateAsset(new SpriteAtlas(), v1Path);
-                var v2Atlas = new SpriteAtlasAsset();
-                try
-                {
-                    SpriteAtlasAsset.Save(v2Atlas, v2Path);
-                }
-                finally
-                {
-                    UnityEngine.Object.DestroyImmediate(v2Atlas);
-                }
-                AssetDatabase.ImportAsset(v2Path, ImportAssetOptions.ForceUpdate);
-
-                int removedCount = (int)InvokePrivateStatic(
-                    "RemoveInactiveAtlasAssets",
-                    folder,
-                    true);
-
-                Assert.AreEqual(1, removedCount);
-                Assert.IsFalse(File.Exists(Path.GetFullPath(v1Path)));
-                Assert.IsTrue(File.Exists(Path.GetFullPath(v2Path)));
             }
             finally
             {
@@ -195,6 +264,20 @@ namespace UMA.Editors.Tests
             AssetDatabase.AddObjectToAsset(sprite, texture);
             AssetDatabase.ImportAsset(texturePath, ImportAssetOptions.ForceUpdate);
             return sprite;
+        }
+
+        private static void CreateWardrobeRecipeAsset(
+            string folder,
+            string name,
+            string region,
+            string race,
+            Sprite sprite)
+        {
+            UMAWardrobeRecipe recipe = ScriptableObject.CreateInstance<UMAWardrobeRecipe>();
+            recipe.name = name;
+            recipe.wardrobeSlot = region;
+            recipe.wardrobeRecipeThumbs.Add(new WardrobeRecipeThumb(race, sprite));
+            AssetDatabase.CreateAsset(recipe, folder + "/" + name + ".asset");
         }
 
         private static int GetSpriteAtlasV2PackableCount(string atlasPath)

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
@@ -97,6 +97,45 @@ namespace UMA.Editors.Tests
         [Test]
         [Category("UMA")]
         [Category("IconCreator")]
+        public void SpriteAtlasV2RebuildRecreatesDeletedAssetWithCachedGuid()
+        {
+            string folder = CreateTestFolder();
+            string atlasPath = folder + "/UMAIcons_Deleted_TestRegion.spriteatlasv2";
+            try
+            {
+                Sprite sprite = CreateSpriteAsset(folder, "Replacement");
+                var originalAtlas = new SpriteAtlasAsset();
+                try
+                {
+                    SpriteAtlasAsset.Save(originalAtlas, atlasPath);
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(originalAtlas);
+                }
+                AssetDatabase.ImportAsset(atlasPath, ImportAssetOptions.ForceUpdate);
+
+                Assert.IsTrue(AssetDatabase.DeleteAsset(atlasPath));
+                Assert.IsFalse(File.Exists(Path.GetFullPath(atlasPath)));
+
+                InvokePrivateStatic(
+                    "RebuildAtlas",
+                    atlasPath,
+                    new List<Sprite> { sprite },
+                    true);
+
+                Assert.IsTrue(File.Exists(Path.GetFullPath(atlasPath)));
+                Assert.AreEqual(1, GetSpriteAtlasV2PackableCount(atlasPath));
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folder);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
         public void InactiveGeneratedAtlasVersionIsRemoved()
         {
             string folder = CreateTestFolder();

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
@@ -1,7 +1,13 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.U2D;
+using UnityEngine;
+using UnityEngine.U2D;
 
 namespace UMA.Editors.Tests
 {
@@ -25,6 +31,157 @@ namespace UMA.Editors.Tests
         {
             Assert.Throws<ArgumentException>(() =>
                 IconCreatorSpriteAtlasUtility.GetAtlasFolder(Path.GetTempPath()));
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void SpriteAtlasV2ModesAreDetected()
+        {
+            Assert.IsTrue((bool)InvokePrivateStatic(
+                "IsSpriteAtlasV2Enabled",
+                SpritePackerMode.SpriteAtlasV2));
+            Assert.IsTrue((bool)InvokePrivateStatic(
+                "IsSpriteAtlasV2Enabled",
+                SpritePackerMode.SpriteAtlasV2Build));
+            Assert.IsFalse((bool)InvokePrivateStatic(
+                "IsSpriteAtlasV2Enabled",
+                SpritePackerMode.AlwaysOnAtlas));
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void SpriteAtlasV2RebuildReusesAssetAndReplacesPackables()
+        {
+            string folder = CreateTestFolder();
+            string atlasPath = folder + "/UMAIcons_TestRace_TestRegion.spriteatlasv2";
+            try
+            {
+                Sprite firstSprite = CreateSpriteAsset(folder, "First");
+                Sprite secondSprite = CreateSpriteAsset(folder, "Second");
+
+                InvokePrivateStatic(
+                    "RebuildAtlas",
+                    atlasPath,
+                    new List<Sprite> { firstSprite, secondSprite },
+                    true);
+
+                string originalGuid = AssetDatabase.AssetPathToGUID(atlasPath);
+                Assert.IsNotEmpty(originalGuid);
+                Assert.AreEqual(2, GetSpriteAtlasV2PackableCount(atlasPath));
+
+                InvokePrivateStatic(
+                    "RebuildAtlas",
+                    atlasPath,
+                    new List<Sprite> { secondSprite },
+                    true);
+
+                Assert.AreEqual(originalGuid, AssetDatabase.AssetPathToGUID(atlasPath));
+                Assert.AreEqual(1, GetSpriteAtlasV2PackableCount(atlasPath));
+
+                SpriteAtlasImporter importer =
+                    AssetImporter.GetAtPath(atlasPath) as SpriteAtlasImporter;
+                Assert.IsNotNull(importer);
+                Assert.IsTrue(importer.includeInBuild);
+                Assert.AreEqual(4, importer.packingSettings.padding);
+                Assert.IsFalse(importer.packingSettings.enableRotation);
+                Assert.IsFalse(importer.textureSettings.generateMipMaps);
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folder);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void InactiveGeneratedAtlasVersionIsRemoved()
+        {
+            string folder = CreateTestFolder();
+            string atlasName = "/UMAIcons_TestRace_TestRegion";
+            string v1Path = folder + atlasName + ".spriteatlas";
+            string v2Path = folder + atlasName + ".spriteatlasv2";
+            try
+            {
+                AssetDatabase.CreateAsset(new SpriteAtlas(), v1Path);
+                var v2Atlas = new SpriteAtlasAsset();
+                try
+                {
+                    SpriteAtlasAsset.Save(v2Atlas, v2Path);
+                }
+                finally
+                {
+                    UnityEngine.Object.DestroyImmediate(v2Atlas);
+                }
+                AssetDatabase.ImportAsset(v2Path, ImportAssetOptions.ForceUpdate);
+
+                int removedCount = (int)InvokePrivateStatic(
+                    "RemoveInactiveAtlasAssets",
+                    folder,
+                    true);
+
+                Assert.AreEqual(1, removedCount);
+                Assert.IsFalse(File.Exists(Path.GetFullPath(v1Path)));
+                Assert.IsTrue(File.Exists(Path.GetFullPath(v2Path)));
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(folder);
+            }
+        }
+
+        private static string CreateTestFolder()
+        {
+            string folderName = "IconCreatorAtlasTests_" + Guid.NewGuid().ToString("N");
+            AssetDatabase.CreateFolder("Assets", folderName);
+            return "Assets/" + folderName;
+        }
+
+        private static Sprite CreateSpriteAsset(string folder, string name)
+        {
+            var texture = new Texture2D(2, 2, TextureFormat.RGBA32, false)
+            {
+                name = name + "Texture"
+            };
+            string texturePath = folder + "/" + name + ".asset";
+            AssetDatabase.CreateAsset(texture, texturePath);
+
+            Sprite sprite = Sprite.Create(
+                texture,
+                new Rect(0f, 0f, texture.width, texture.height),
+                new Vector2(0.5f, 0.5f));
+            sprite.name = name;
+            AssetDatabase.AddObjectToAsset(sprite, texture);
+            AssetDatabase.ImportAsset(texturePath, ImportAssetOptions.ForceUpdate);
+            return sprite;
+        }
+
+        private static int GetSpriteAtlasV2PackableCount(string atlasPath)
+        {
+            SpriteAtlasAsset atlas = SpriteAtlasAsset.Load(atlasPath);
+            try
+            {
+                var serializedAtlas = new SerializedObject(atlas);
+                SerializedProperty packables =
+                    serializedAtlas.FindProperty("m_ImporterData.packables");
+                Assert.IsNotNull(packables);
+                return packables.arraySize;
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(atlas);
+            }
+        }
+
+        private static object InvokePrivateStatic(string methodName, params object[] arguments)
+        {
+            MethodInfo method = typeof(IconCreatorSpriteAtlasUtility).GetMethod(
+                methodName,
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(method, "Missing method: " + methodName);
+            return method.Invoke(null, arguments);
         }
     }
 }

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs
@@ -1,0 +1,31 @@
+#if UNITY_EDITOR
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace UMA.Editors.Tests
+{
+    public sealed class IconCreatorSpriteAtlasUtilityTests
+    {
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void AtlasFolderIsCreatedUnderTheIconRoot()
+        {
+            Assert.AreEqual(
+                "Assets/UMA/UMA3/Wearables/Icons/SpriteAtlases",
+                IconCreatorSpriteAtlasUtility.GetAtlasFolder(
+                    "Assets/UMA/UMA3/Wearables/Icons"));
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void AtlasFolderRejectsPathsOutsideAssets()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                IconCreatorSpriteAtlasUtility.GetAtlasFolder(Path.GetTempPath()));
+        }
+    }
+}
+#endif

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs.meta
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorSpriteAtlasUtilityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19d29d3056454ace828d63d99f534ef0

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
@@ -35,6 +35,32 @@ namespace UMA.Editors.Tests
         [Test]
         [Category("UMA")]
         [Category("IconCreator")]
+        public void CaptureSupersamplingIsClampedBetweenOneAndFour()
+        {
+            GameObject gameObject = new GameObject("Icon Creator supersampling test");
+            try
+            {
+                IconCreator iconCreator = gameObject.AddComponent<IconCreator>();
+                iconCreator.CaptureSupersampling = 8;
+
+                InvokePrivate(iconCreator, "OnValidate");
+
+                Assert.AreEqual(4, iconCreator.CaptureSupersampling);
+
+                iconCreator.CaptureSupersampling = 0;
+                InvokePrivate(iconCreator, "OnValidate");
+
+                Assert.AreEqual(1, iconCreator.CaptureSupersampling);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(gameObject);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
         public void CameraCaptureUsesIconDimensions()
         {
             GameObject gameObject = new GameObject("Icon Creator capture test");
@@ -54,6 +80,7 @@ namespace UMA.Editors.Tests
 
                 IconCreator iconCreator = gameObject.AddComponent<IconCreator>();
                 iconCreator.IconDimensions = new Vector2(19f, 11f);
+                iconCreator.CaptureSupersampling = 2;
 
                 bool captured = (bool)InvokePrivate(
                     iconCreator,

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
@@ -1,0 +1,146 @@
+#if UNITY_EDITOR
+using System;
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace UMA.Editors.Tests
+{
+    public sealed class IconCreatorTests
+    {
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void IconDimensionsAreClampedToPositiveIntegers()
+        {
+            GameObject gameObject = new GameObject("Icon Creator dimension test");
+            try
+            {
+                IconCreator iconCreator = gameObject.AddComponent<IconCreator>();
+                iconCreator.IconDimensions = new Vector2(-12.4f, 128.6f);
+
+                InvokePrivate(iconCreator, "OnValidate");
+
+                Assert.AreEqual(new Vector2(1f, 129f), iconCreator.IconDimensions);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(gameObject);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void CameraCaptureUsesIconDimensions()
+        {
+            GameObject gameObject = new GameObject("Icon Creator capture test");
+            RenderTexture renderTexture = null;
+            Texture2D loadedTexture = null;
+            string outputPath = Path.Combine(
+                Path.GetTempPath(),
+                "UMAIconCreator_" + Guid.NewGuid().ToString("N") + ".png");
+            try
+            {
+                Camera camera = gameObject.AddComponent<Camera>();
+                renderTexture = new RenderTexture(32, 24, 0, RenderTextureFormat.ARGB32);
+                renderTexture.Create();
+                camera.targetTexture = renderTexture;
+
+                IconCreator iconCreator = gameObject.AddComponent<IconCreator>();
+                iconCreator.IconDimensions = new Vector2(19f, 11f);
+
+                bool captured = (bool)InvokePrivate(
+                    iconCreator,
+                    "CaptureRenderTextureToPng",
+                    camera,
+                    outputPath);
+
+                Assert.IsTrue(captured);
+                Assert.IsTrue(File.Exists(outputPath));
+
+                loadedTexture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+                Assert.IsTrue(loadedTexture.LoadImage(File.ReadAllBytes(outputPath)));
+                Assert.AreEqual(19, loadedTexture.width);
+                Assert.AreEqual(11, loadedTexture.height);
+            }
+            finally
+            {
+                if (loadedTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(loadedTexture);
+                }
+                if (renderTexture != null)
+                {
+                    Camera camera = gameObject.GetComponent<Camera>();
+                    if (camera != null)
+                    {
+                        camera.targetTexture = null;
+                    }
+                    renderTexture.Release();
+                    UnityEngine.Object.DestroyImmediate(renderTexture);
+                }
+                UnityEngine.Object.DestroyImmediate(gameObject);
+                if (File.Exists(outputPath))
+                {
+                    File.Delete(outputPath);
+                }
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void RecipeTextureIsResampledToIconDimensions()
+        {
+            Texture2D sourceTexture = new Texture2D(8, 8, TextureFormat.RGBA32, false);
+            Texture2D outputTexture = null;
+            try
+            {
+                outputTexture = (Texture2D)InvokePrivateStatic(
+                    typeof(IconCreator),
+                    "GetReadableTexture2D",
+                    sourceTexture,
+                    new Rect(0.25f, 0.25f, 0.5f, 0.5f),
+                    13,
+                    7);
+
+                Assert.IsNotNull(outputTexture);
+                Assert.AreEqual(13, outputTexture.width);
+                Assert.AreEqual(7, outputTexture.height);
+            }
+            finally
+            {
+                if (outputTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(outputTexture);
+                }
+                UnityEngine.Object.DestroyImmediate(sourceTexture);
+            }
+        }
+
+        private static object InvokePrivate(object target, string methodName, params object[] arguments)
+        {
+            MethodInfo method = target.GetType().GetMethod(
+                methodName,
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(method, "Missing method: " + methodName);
+            return method.Invoke(target, arguments);
+        }
+
+        private static object InvokePrivateStatic(
+            Type targetType,
+            string methodName,
+            params object[] arguments)
+        {
+            MethodInfo method = targetType.GetMethod(
+                methodName,
+                BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(method, "Missing method: " + methodName);
+            return method.Invoke(null, arguments);
+        }
+    }
+
+}
+#endif

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
@@ -3,6 +3,8 @@ using System;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
+using UMA.CharacterSystem;
+using UnityEditor;
 using UnityEngine;
 
 namespace UMA.Editors.Tests
@@ -161,6 +163,71 @@ namespace UMA.Editors.Tests
                 UnityEngine.Object.DestroyImmediate(sourceTexture);
                 UnityEngine.Object.DestroyImmediate(gameObject);
             }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void ExistingThumbnailPathIsPreservedForMatchingRace()
+        {
+            string folderName = "IconCreatorTests_" + Guid.NewGuid().ToString("N");
+            string assetFolder = "Assets/" + folderName;
+            string absoluteFolder = Path.Combine(Application.dataPath, folderName);
+            string assetPath = assetFolder + "/7_ExistingThumbnail.png";
+            string absolutePath = Path.Combine(absoluteFolder, "7_ExistingThumbnail.png");
+            GameObject gameObject = new GameObject("Icon Creator existing path test");
+            UMAWardrobeRecipe recipe = ScriptableObject.CreateInstance<UMAWardrobeRecipe>();
+            Texture2D texture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+            try
+            {
+                AssetDatabase.CreateFolder("Assets", folderName);
+                File.WriteAllBytes(absolutePath, texture.EncodeToPNG());
+
+                recipe.name = "Test Recipe";
+                recipe.wardrobeRecipeThumbs.Add(new WardrobeRecipeThumb
+                {
+                    race = "Test Race",
+                    filename = assetPath
+                });
+
+                IconCreator iconCreator = gameObject.AddComponent<IconCreator>();
+                string outputPath = (string)InvokePrivate(
+                    iconCreator,
+                    "GetThumbnailOutputPath",
+                    recipe,
+                    "Test Race",
+                    absoluteFolder);
+
+                Assert.AreEqual(NormalizePath(absolutePath), NormalizePath(outputPath));
+
+                string otherRaceOutputPath = (string)InvokePrivate(
+                    iconCreator,
+                    "GetThumbnailOutputPath",
+                    recipe,
+                    "Other Race",
+                    absoluteFolder);
+
+                Assert.AreNotEqual(NormalizePath(absolutePath), NormalizePath(otherRaceOutputPath));
+                Assert.AreEqual(
+                    NormalizePath(absoluteFolder),
+                    NormalizePath(Path.GetDirectoryName(otherRaceOutputPath)));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(texture);
+                UnityEngine.Object.DestroyImmediate(recipe);
+                UnityEngine.Object.DestroyImmediate(gameObject);
+                AssetDatabase.DeleteAsset(assetFolder);
+                if (Directory.Exists(absoluteFolder))
+                {
+                    Directory.Delete(absoluteFolder, true);
+                }
+            }
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return Path.GetFullPath(path).Replace('\\', '/');
         }
 
         private static object InvokePrivate(object target, string methodName, params object[] arguments)

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
@@ -44,6 +44,8 @@ namespace UMA.Editors.Tests
             try
             {
                 Camera camera = gameObject.AddComponent<Camera>();
+                camera.clearFlags = CameraClearFlags.SolidColor;
+                camera.backgroundColor = new Color(0.1f, 0.7f, 0.2f, 1f);
                 renderTexture = new RenderTexture(32, 24, 0, RenderTextureFormat.ARGB32);
                 renderTexture.Create();
                 camera.targetTexture = renderTexture;
@@ -64,6 +66,11 @@ namespace UMA.Editors.Tests
                 Assert.IsTrue(loadedTexture.LoadImage(File.ReadAllBytes(outputPath)));
                 Assert.AreEqual(19, loadedTexture.width);
                 Assert.AreEqual(11, loadedTexture.height);
+                Assert.AreSame(renderTexture, camera.targetTexture);
+
+                Color centerPixel = loadedTexture.GetPixel(loadedTexture.width / 2, loadedTexture.height / 2);
+                Assert.Greater(centerPixel.g, centerPixel.r);
+                Assert.Greater(centerPixel.g, centerPixel.b);
             }
             finally
             {
@@ -92,7 +99,7 @@ namespace UMA.Editors.Tests
         [Test]
         [Category("UMA")]
         [Category("IconCreator")]
-        public void RecipeTextureIsResampledToIconDimensions()
+        public void TextureCropCanBeResampledToRequestedDimensions()
         {
             Texture2D sourceTexture = new Texture2D(8, 8, TextureFormat.RGBA32, false);
             Texture2D outputTexture = null;
@@ -117,6 +124,42 @@ namespace UMA.Editors.Tests
                     UnityEngine.Object.DestroyImmediate(outputTexture);
                 }
                 UnityEngine.Object.DestroyImmediate(sourceTexture);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void TextureDerivedThumbnailPreservesNativeCropDimensionsByDefault()
+        {
+            GameObject gameObject = new GameObject("Icon Creator texture dimension test");
+            Texture2D sourceTexture = new Texture2D(1024, 1024, TextureFormat.RGBA32, false);
+            try
+            {
+                IconCreator iconCreator = gameObject.AddComponent<IconCreator>();
+                iconCreator.IconDimensions = new Vector2(160f, 90f);
+
+                Vector2Int dimensions = (Vector2Int)InvokePrivate(
+                    iconCreator,
+                    "GetTextureThumbnailDimensions",
+                    sourceTexture,
+                    new Rect(0.25f, 0.25f, 0.5f, 0.5f));
+
+                Assert.AreEqual(new Vector2Int(512, 512), dimensions);
+
+                iconCreator.ResizeTextureDerivedThumbnails = true;
+                dimensions = (Vector2Int)InvokePrivate(
+                    iconCreator,
+                    "GetTextureThumbnailDimensions",
+                    sourceTexture,
+                    new Rect(0.25f, 0.25f, 0.5f, 0.5f));
+
+                Assert.AreEqual(new Vector2Int(160, 90), dimensions);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(sourceTexture);
+                UnityEngine.Object.DestroyImmediate(gameObject);
             }
         }
 

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs
@@ -252,6 +252,141 @@ namespace UMA.Editors.Tests
             }
         }
 
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void DetachedRecipeDoesNotRetainThumbnailAssets()
+        {
+            UMAWardrobeRecipe sourceRecipe = ScriptableObject.CreateInstance<UMAWardrobeRecipe>();
+            UMAWardrobeRecipe detachedRecipe = null;
+            Texture2D texture = new Texture2D(4, 4, TextureFormat.RGBA32, false);
+            Sprite sprite = Sprite.Create(texture, new Rect(0, 0, 4, 4), Vector2.zero);
+            try
+            {
+                sourceRecipe.name = "Detached Recipe Test";
+                sourceRecipe.recipeString = "serialized recipe data";
+                sourceRecipe.thumbnailFromTexture = true;
+                sourceRecipe.wardrobeRecipeThumbs.Add(new WardrobeRecipeThumb("Test Race", sprite));
+
+                detachedRecipe = (UMAWardrobeRecipe)InvokePrivateStatic(
+                    typeof(IconCreator),
+                    "CreateDetachedRecipe",
+                    sourceRecipe);
+
+                Assert.AreNotSame(sourceRecipe, detachedRecipe);
+                Assert.AreEqual(sourceRecipe.name, detachedRecipe.name);
+                Assert.AreEqual(sourceRecipe.recipeString, detachedRecipe.recipeString);
+                Assert.AreEqual(sourceRecipe.thumbnailFromTexture, detachedRecipe.thumbnailFromTexture);
+                Assert.IsNotNull(detachedRecipe.wardrobeRecipeThumbs);
+                Assert.IsEmpty(detachedRecipe.wardrobeRecipeThumbs);
+                Assert.AreEqual(HideFlags.HideAndDontSave, detachedRecipe.hideFlags);
+                Assert.AreSame(sprite, sourceRecipe.wardrobeRecipeThumbs[0].thumb);
+            }
+            finally
+            {
+                if (detachedRecipe != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(detachedRecipe);
+                }
+                UnityEngine.Object.DestroyImmediate(sprite);
+                UnityEngine.Object.DestroyImmediate(texture);
+                UnityEngine.Object.DestroyImmediate(sourceRecipe);
+            }
+        }
+
+        [Test]
+        [Category("UMA")]
+        [Category("IconCreator")]
+        public void ThumbnailWriteOverwritesImportedTextureWithoutChangingGuid()
+        {
+            string folderName = "IconCreatorTests_" + Guid.NewGuid().ToString("N");
+            string assetFolder = "Assets/" + folderName;
+            string absoluteFolder = Path.Combine(Application.dataPath, folderName);
+            string assetPath = assetFolder + "/ExistingThumbnail.png";
+            string absolutePath = Path.Combine(absoluteFolder, "ExistingThumbnail.png");
+            Texture2D initialTexture = new Texture2D(2, 2, TextureFormat.RGBA32, false);
+            Texture2D replacementTexture = new Texture2D(8, 4, TextureFormat.RGBA32, false);
+            UMAWardrobeRecipe recipe = ScriptableObject.CreateInstance<UMAWardrobeRecipe>();
+            FileStream thumbnailLock = null;
+            System.Threading.Tasks.Task releaseLock = null;
+            try
+            {
+                AssetDatabase.CreateFolder("Assets", folderName);
+                File.WriteAllBytes(absolutePath, initialTexture.EncodeToPNG());
+                AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceSynchronousImport);
+
+                TextureImporter textureImporter = AssetImporter.GetAtPath(assetPath) as TextureImporter;
+                Assert.IsNotNull(textureImporter);
+                textureImporter.textureType = TextureImporterType.Sprite;
+                textureImporter.spriteImportMode = SpriteImportMode.Single;
+                textureImporter.SaveAndReimport();
+
+                string originalGuid = AssetDatabase.AssetPathToGUID(assetPath);
+                Assert.IsNotEmpty(originalGuid);
+                Sprite importedSprite = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
+                Assert.IsNotNull(importedSprite);
+                Assert.IsNotNull(importedSprite.texture);
+                recipe.wardrobeRecipeThumbs.Add(new WardrobeRecipeThumb("Test Race", importedSprite));
+
+                byte[] replacementBytes = replacementTexture.EncodeToPNG();
+                recipe.wardrobeRecipeThumbs[0].thumb = null;
+                InvokePrivateStatic(
+                    typeof(IconCreator),
+                    "UnloadThumbnailAsset",
+                    assetPath);
+                importedSprite = null;
+                EditorUtility.UnloadUnusedAssetsImmediate(false);
+
+                thumbnailLock = File.Open(
+                    absolutePath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.Read);
+                FileStream lockToRelease = thumbnailLock;
+                releaseLock = System.Threading.Tasks.Task.Run(() =>
+                {
+                    System.Threading.Thread.Sleep(100);
+                    lockToRelease.Dispose();
+                });
+                InvokePrivateStatic(
+                    typeof(IconCreator),
+                    "WriteThumbnailFile",
+                    absolutePath,
+                    replacementBytes);
+                releaseLock.Wait();
+                Assert.IsEmpty(Directory.GetFiles(absoluteFolder, "*.tmp"));
+                AssetDatabase.ImportAsset(assetPath, ImportAssetOptions.ForceSynchronousImport);
+
+                importedSprite = AssetDatabase.LoadAssetAtPath<Sprite>(assetPath);
+                Assert.IsNotNull(importedSprite);
+                Assert.AreEqual(8, importedSprite.texture.width);
+                Assert.AreEqual(4, importedSprite.texture.height);
+                Assert.AreEqual(originalGuid, AssetDatabase.AssetPathToGUID(assetPath));
+            }
+            finally
+            {
+                thumbnailLock?.Dispose();
+                releaseLock?.Wait(1000);
+                if (recipe != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(recipe);
+                }
+                if (replacementTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(replacementTexture);
+                }
+                if (initialTexture != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(initialTexture);
+                }
+                AssetDatabase.DeleteAsset(assetFolder);
+                if (Directory.Exists(absoluteFolder))
+                {
+                    Directory.Delete(absoluteFolder, true);
+                }
+            }
+        }
+
         private static string NormalizePath(string path)
         {
             return Path.GetFullPath(path).Replace('\\', '/');

--- a/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs.meta
+++ b/UMAProject/Assets/UMA/Core/Editor/Tests/IconCreatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 619c6a107d364ca1bd605bdf4ed892aa

--- a/UMAProject/Assets/UMA/Docs/!README.md
+++ b/UMAProject/Assets/UMA/Docs/!README.md
@@ -38,6 +38,7 @@ You can open these guides inside Unity from `UMA > View Documentation`.
 - [Dynamic Character Avatar](DynamicCharacterAvatar.md)
 - [UMA Generator Setup](UMAGeneratorSetup.md)
 - [UMA Asset Indexer and Global Library](UMAAssetIndexer.md)
+- [Icon Creator and Thumbnail Sprite Atlases](IconCreator.md)
 - [Addressables](Addressables.md)
 
 ### Artist content creation

--- a/UMAProject/Assets/UMA/Docs/IconCreator.md
+++ b/UMAProject/Assets/UMA/Docs/IconCreator.md
@@ -1,0 +1,132 @@
+# Icon Creator and Thumbnail Sprite Atlases
+
+UMA's Icon Creator generates wardrobe thumbnails for the active race and can optionally group those thumbnails into Sprite Atlas V2 assets.
+
+The Icon Creator and atlas builder are separate operations:
+
+- Thumbnail generation works without Sprite Atlases.
+- Atlas generation is opt-in and requires Sprite Atlas V2.
+- Generated PNG files and atlas assets are project content. They are not required for the Icon Creator code itself to compile or run.
+
+## Configure the Icon Creator
+
+Open a scene containing an `IconCreator` component and assign:
+
+- A `DynamicCharacterAvatar` with an active race.
+- One or more cameras with target Render Textures.
+- The wardrobe regions handled by each camera.
+- A Root Folder inside the project's `Assets` folder.
+- The desired Icon Dimensions.
+
+The Root Folder controls both thumbnail output and atlas scope. For example:
+
+`Assets/UMA/UMA3/Wearables/Icons`
+
+Thumbnails are written beneath that folder using the following layout:
+
+`<Root Folder>/<Wardrobe Region>/<Race Name>`
+
+## Generate Thumbnails
+
+Use `Render Now` to generate the selected wardrobe region or `Generate All Icons` to process every region available to the active avatar.
+
+Camera-rendered thumbnails use Icon Dimensions for their final pixel size. Capture Supersampling temporarily renders the assigned camera at a higher resolution and downsamples the result. This improves edge quality without creating additional project assets. Temporary Render Textures are released after each capture.
+
+Texture-derived thumbnails preserve the source crop dimensions by default. Enable Resize Texture Derived Thumbnails when those crops should instead be resampled to Icon Dimensions.
+
+### File names and references
+
+When a recipe already references a thumbnail in the target output folder, Icon Creator overwrites that file in place. The existing Unity `.meta` file and asset GUID are preserved.
+
+When no thumbnail exists in the target folder, Icon Creator creates a deterministic name using the recipe name and the first eight characters of the recipe asset GUID. The GUID suffix prevents recipes with identical names from overwriting one another. Subsequent runs preserve and overwrite the newly assigned thumbnail path.
+
+Before overwriting imported thumbnail files, Icon Creator temporarily releases managed Sprite Atlas and Sprite references. Recipe references are restored after generation and saved only when restoration succeeds.
+
+## Generate Sprite Atlases
+
+Sprite Atlas generation is optional. To enable it:
+
+1. Open `Edit > Project Settings > Editor`.
+2. Under `Sprite Atlas`, set Mode to `Sprite Atlas V2 - Enabled`.
+3. Select the GameObject containing `IconCreator`.
+4. In the Icon Creator inspector, select `Rebuild Thumbnail Atlases`.
+
+`Sprite Atlas V2 - Enabled for Builds` only activates packed atlas textures during builds. Icon Creator requires `Sprite Atlas V2 - Enabled` so the atlas can also be inspected and validated in the Editor. If that mode is not enabled, the atlas builder stops without changing assets and displays an error explaining the required setting.
+
+The atlas builder does not support or create Sprite Atlas V1 assets.
+
+## Atlas Scope and Grouping
+
+The builder scans wardrobe recipe thumbnail references, but includes a Sprite only when its source asset is physically beneath the configured Root Folder. References to thumbnails elsewhere in the project are left unchanged and are not added to generated atlases.
+
+Included Sprites are grouped by:
+
+- Race name
+- Wardrobe region
+
+Generated atlases are written to:
+
+`<Root Folder>/SpriteAtlases`
+
+Atlas names use this pattern:
+
+`UMAIcons_<Race>_<Wardrobe Region>.spriteatlasv2`
+
+Rebuilding an existing group replaces its packable list while preserving the atlas asset path and GUID. Atlases for groups that no longer contain eligible thumbnails have their packable lists cleared.
+
+## Atlas Import Settings
+
+Generated atlases use the following defaults:
+
+- Included in builds
+- Rotation disabled
+- Padding: 4 pixels
+- Maximum texture size: 2048
+- Bilinear filtering
+- Mipmaps disabled
+- sRGB enabled
+- Compressed using the default platform settings
+
+The original thumbnail Sprites remain atlas packables and remain referenced by wardrobe recipes. The builder does not delete source PNG files.
+
+## Conflicts
+
+A Sprite can belong to only one generated race-and-region group. If recipes attempt to assign the same Sprite to conflicting groups, the first deterministic assignment is retained and a warning is logged.
+
+The builder also warns when an eligible Sprite is already included by a Sprite Atlas V2 asset outside the managed `SpriteAtlases` folder. External atlases are never modified automatically.
+
+## Recommended Regeneration Workflow
+
+1. Configure the active race, cameras, Render Textures, and Icon Dimensions.
+2. Generate one region and inspect representative thumbnails.
+3. Generate all required regions for each supported race.
+4. Confirm recipe thumbnail references point beneath the configured Root Folder.
+5. Enable `Sprite Atlas V2 - Enabled` if atlasing is desired.
+6. Rebuild Thumbnail Atlases.
+7. Inspect the atlas pack previews and test the character creator UI.
+8. Make a player build and confirm the expected atlases are included.
+
+Generated atlases can be removed and rebuilt from the current recipe thumbnail references. Normally keep existing thumbnail PNGs and their `.meta` files: deleting a referenced thumbnail can cause Icon Creator to create a new deterministic filename and assign a new recipe reference. Review generated asset changes before committing them to source control.
+
+## Troubleshooting
+
+### Atlas generation reports that Sprite Atlas V2 is required
+
+Set `Edit > Project Settings > Editor > Sprite Atlas > Mode` to `Sprite Atlas V2 - Enabled`. Thumbnail generation remains available when atlasing is disabled.
+
+### A recipe thumbnail is not included in an atlas
+
+Check that:
+
+- The recipe has a Sprite assigned for the intended race.
+- The recipe has a wardrobe region.
+- The Sprite asset is beneath the configured Root Folder.
+- The Sprite is not already assigned to a conflicting generated or external atlas.
+
+### A regenerated thumbnail receives a GUID suffix
+
+The recipe did not reference an existing thumbnail inside its target output folder. The suffix provides a stable, collision-resistant name for the new file. Later runs overwrite that assigned path.
+
+### Thumbnail replacement fails on Windows
+
+Close inspectors or external programs displaying the PNG and retry. Icon Creator releases its managed Unity references and retries transient file-sharing failures, but another process can still hold an exclusive file handle.

--- a/UMAProject/Assets/UMA/Docs/IconCreator.md.meta
+++ b/UMAProject/Assets/UMA/Docs/IconCreator.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6ea46b06f02ec94593d9340ba3c09ea
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

This adds optional Sprite Atlas V2 generation to UMA's existing Icon Creator workflow and improves thumbnail regeneration reliability.

### Thumbnail generation

- Camera-rendered thumbnails use the configured Icon Dimensions for their final pixel size.
- Configurable capture supersampling renders camera thumbnails at a temporary higher resolution and downsamples them for improved edge quality.
- Texture-derived thumbnails—such as face, makeup, and scar thumbnails—preserve the pixel dimensions of their selected source crop by default instead of being forced to the general Icon Dimensions.
- Texture-derived thumbnails can optionally be resized to Icon Dimensions.
- Existing thumbnails in the configured output folder are overwritten in place, preserving their filenames, `.meta` files, GUIDs, and recipe references.
- New thumbnails use deterministic filenames containing the recipe name and a short recipe GUID suffix, preventing recipes with identical names from overwriting one another.
- Thumbnail and atlas references are temporarily released during regeneration to reduce Windows file-sharing errors, with replacement retries for transient file locks.

### Sprite Atlas generation

- Adds an optional `Rebuild Thumbnail Atlases` action to the Icon Creator inspector.
- Supports Sprite Atlas V2 only.
- Atlas generation requires `Sprite Atlas V2 - Enabled` in `Edit > Project Settings > Editor`.
- Thumbnail generation continues to work normally when atlasing is not enabled.
- Only thumbnail Sprites physically located beneath the configured Icon Creator root are eligible for generated atlases.
- Sprites are grouped by race and wardrobe region.
- Existing generated atlas paths and GUIDs are preserved when rebuilding.
- Obsolete generated atlases have their packable lists cleared rather than being deleted.
- Generated atlases are included in builds and use consistent packing and texture settings.
- Conflicting or external atlas assignments produce warnings rather than silently modifying unrelated atlases.

Wardrobe recipes continue referencing their original thumbnail Sprites. Unity resolves those Sprite references to their packed atlas representations when the atlases are available.

## Configuration scope

This pull request does not change the existing Photo Booth scene, camera RenderTexture dimensions, or checked-in thumbnail resolution settings. Those remain configured at 128×128.

Generated thumbnail PNGs and Sprite Atlas assets are intentionally excluded from this pull request. Projects can regenerate them through the Icon Creator workflow after configuring their preferred dimensions and enabling Sprite Atlas V2 if desired.

## Documentation

Adds an Icon Creator guide covering:

- Thumbnail configuration and regeneration
- Camera and texture-derived thumbnail sizing
- Filename and GUID preservation
- Sprite Atlas V2 setup
- Atlas scope, grouping, and import settings
- Recommended regeneration workflow
- Conflict handling and troubleshooting

## Validation

- Icon Creator EditMode tests: 16/16 passed
- Markdown viewer EditMode tests: 4/4 passed
- Manually regenerated Human Female 3.0 and Human Male 3.0 thumbnails
- Manually rebuilt and inspected Sprite Atlas V2 assets
- Exercised the player-build workflow with generated atlases
